### PR TITLE
Add sarif4k as a submodule

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           # required for correct codecov upload
           fetch-depth: 0
+          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/deploy_images.yml
+++ b/.github/workflows/deploy_images.yml
@@ -18,12 +18,14 @@ jobs:
         with:
           path: save-cloud
           fetch-depth: 0
+          submodules: true
       - name: checkout save-core
         uses: actions/checkout@v2.4.0
         with:
           repository: analysis-dev/save
           path: save
           fetch-depth: 0
+          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
+        with:
+          submodules: true
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sarif4k"]
+	path = sarif4k
+	url = https://github.com/analysis-dev/sarif4k

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include("save-frontend")
 include("save-cloud-common")
 include("save-agent")
 include("save-preprocessor")
+includeBuild("sarif4k")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
New versions of save-warn-plugin have sarif4k as a transitive dependency. But for now it's not available anywhere.