### PR TITLE
Support `/projects/non-deleted` for unauthorized requests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,8 @@ dependencies {
 
 tasks.withType<org.liquibase.gradle.LiquibaseTask>().configureEach {
     this.javaLauncher.set(project.extensions.getByType<JavaToolchainService>().launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(Versions.jdk))
+        // liquibase-core 4.7.0 and liquibase-gradle 2.1.1 fails on Java >= 13
+        languageVersion.set(JavaLanguageVersion.of(11))
     })
 }
 

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ProjectController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ProjectController.kt
@@ -63,7 +63,7 @@ class ProjectController(private val projectService: ProjectService,
      */
     @GetMapping("/not-deleted")
     fun getNotDeletedProjects(authentication: Authentication?) = projectService.getNotDeletedProjects()
-        .filter { project -> authentication?.let { projectPermissionEvaluator.hasPermission(it, project, Permission.READ) } ?: project.public }
+        .filter { projectPermissionEvaluator.hasPermission(authentication, it, Permission.READ) }
 
     /**
      * 200 - if user can access the project

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ProjectController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ProjectController.kt
@@ -62,8 +62,8 @@ class ProjectController(private val projectService: ProjectService,
      * @return a list of projects
      */
     @GetMapping("/not-deleted")
-    fun getNotDeletedProjects(authentication: Authentication) = projectService.getNotDeletedProjects()
-        .filter { projectPermissionEvaluator.hasPermission(authentication, it, Permission.READ) }
+    fun getNotDeletedProjects(authentication: Authentication?) = projectService.getNotDeletedProjects()
+        .filter { project -> authentication?.let { projectPermissionEvaluator.hasPermission(it, project, Permission.READ) } ?: project.public }
 
     /**
      * 200 - if user can access the project

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluator.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluator.kt
@@ -15,7 +15,13 @@ class ProjectPermissionEvaluator {
      * @param permission
      * @return whether user described by [authentication] can have [permission] on project [project]
      */
-    fun hasPermission(authentication: Authentication, project: Project, permission: Permission): Boolean {
+    fun hasPermission(authentication: Authentication?, project: Project, permission: Permission): Boolean {
+        authentication ?: return when (permission) {
+            Permission.READ -> project.public
+            Permission.WRITE -> false
+            Permission.DELETE -> false
+        }
+
         if (authentication.hasRole(Role.ADMIN)) {
             return true
         }


### PR DESCRIPTION
* Handle nullable `Authentication` in `ProjectPermissionEvaluator`
* Run liquibase on Java 11

Closes #542 