### PR TITLE
infra: Update reverse-proxy.conf to support SSL, fix loki

### DIFF
--- a/docker-compose.yaml.template
+++ b/docker-compose.yaml.template
@@ -113,12 +113,13 @@ services:
         constraints:
           - "node.role==manager"
   loki:
-    image: grafana/loki:main-517ba7c
+    image: grafana/loki:2.4.2
     ports:
       - "9110:3100"
-    command: -config.file=/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/loki.yaml
     volumes:
       - "loki-storage:/loki"
+      - "~/configs/loki.yaml:/etc/loki/loki.yaml"
     deploy:
       placement:
         max_replicas_per_node: 1

--- a/save-deploy/loki.yaml
+++ b/save-deploy/loki.yaml
@@ -1,0 +1,36 @@
+### this is the copy of default loki-local.yaml for version 2.4.2
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+### end of default loki config for 2.4.2
+
+frontend:
+  address: 0.0.0.0

--- a/save-deploy/reverse-proxy.conf
+++ b/save-deploy/reverse-proxy.conf
@@ -7,6 +7,15 @@ server {
     listen 80;
     listen [::]:80;
 
+    return 301 https://$http_host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    ssl_certificate cert/server.crt;
+    ssl_certificate_key cert/server.key;
+
     access_log /var/log/nginx/reverse-access.log;
     error_log /var/log/nginx/reverse-error.log;
 
@@ -17,13 +26,13 @@ server {
         proxy_set_header X-Forwarded-Host $host:$server_port;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        # Increase request body size to allow uploading resources for test execution
         client_max_body_size 200M;
     }
 
     location /grafana/ {
         proxy_pass http://127.0.0.1:9100/;
-        # websocket connection is sometimes required between browser and grafana server
+        # webscoket connection is sometimes required between brower and grafana server
+        rewrite ^/grafana/(.*) /$1 break;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
* Update reverse-proxy.conf
* Fix websocket connection for loki
* Add loki.yaml, update to 2.4.2