### PR TITLE
infra: Use env variables in docker-compose.yaml

### DIFF
--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DockerStackConfiguration.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DockerStackConfiguration.kt
@@ -25,8 +25,9 @@ const val MYSQL_STARTUP_DELAY_MILLIS = 10_000L
 fun Project.createStackDeployTask(profile: String) {
     tasks.register("generateComposeFile") {
         description = "Set project version in docker-compose file"
-        val templateFile = "$rootDir/docker-compose.yaml.template"
+        val templateFile = "$rootDir/docker-compose.yaml"
         val composeFile = "$buildDir/docker-compose.yaml"
+        val envFile = "$buildDir/.env"
         inputs.file(templateFile)
         inputs.property("project version", version.toString())
         inputs.property("profile", profile)
@@ -49,13 +50,22 @@ fun Project.createStackDeployTask(profile: String) {
                     } else if (profile == "dev" && it.trim().startsWith("logging:")) {
                         ""
                     } else {
-                        it.replace("{{project.version}}", versionForDockerImages())
-                            .replace("{{profile}}", profile)
+                        it
                     }
                 }
             file(composeFile)
                 .apply { createNewFile() }
                 .writeText(newText)
+        }
+
+        doLast {
+            // https://docs.docker.com/compose/environment-variables/#the-env-file
+            file(envFile).writeText(
+                """
+                    TAG=${versionForDockerImages()}
+                    PROFILE=$profile
+                """.trimIndent()
+            )
         }
     }
 
@@ -90,15 +100,16 @@ fun Project.createStackDeployTask(profile: String) {
             Files.createDirectories(configsDir.resolve("preprocessor"))
         }
         description = "Deploy to docker swarm. If swarm contains more than one node, some registry for built images is required."
-        val args = buildList {
-            add("--compose-file")
-            add("${rootProject.buildDir}/docker-compose.yaml")
+        // this command puts env variables into compose file
+        val composeCmd = "docker-compose -f ${rootProject.buildDir}/docker-compose.yaml --env-file ${rootProject.buildDir}/.env config"
+        val stackCmd = "docker stack deploy --compose-file -" +
             if (useOverride && composeOverride.exists()) {
-                add("--compose-file")
-                add(composeOverride.canonicalPath)
-            }
-        }.toTypedArray()
-        commandLine("docker", "stack", "deploy", *args, "save")
+                " --compose-file ${composeOverride.canonicalPath}"
+            } else {
+                ""
+            } +
+                " save"
+        commandLine("bash", "-c", "'$composeCmd | $stackCmd'")
     }
 
     tasks.register("buildAndDeployDockerStack") {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,10 +17,10 @@ x-logging:
 
 services:
   orchestrator:
-    image: ghcr.io/analysis-dev/save-orchestrator:{{project.version}}
+    image: ghcr.io/analysis-dev/save-orchestrator:${TAG}
     user: root  # to access host's docker socket
     environment:
-      - "SPRING_PROFILES_ACTIVE={{profile}}"
+      - "SPRING_PROFILES_ACTIVE=${PROFILE}"
     ports:
       - "5100:5100"
     volumes:
@@ -35,9 +35,9 @@ services:
         - "prometheus-job=save-orchestrator"
     logging: *loki-logging-jvm
   backend:
-    image: ghcr.io/analysis-dev/save-backend:{{project.version}}
+    image: ghcr.io/analysis-dev/save-backend:${TAG}
     environment:
-      - "SPRING_PROFILES_ACTIVE={{profile}},secure"
+      - "SPRING_PROFILES_ACTIVE=${PROFILE},secure"
       - "MYSQL_USER=/run/secrets/db_username"
       - "MYSQL_PASSWORD_FILE=/run/secrets/db_password"
     secrets:
@@ -54,9 +54,9 @@ services:
         - "prometheus-job=save-backend"
     logging: *loki-logging-jvm
   preprocessor:
-    image: ghcr.io/analysis-dev/save-preprocessor:{{project.version}}
+    image: ghcr.io/analysis-dev/save-preprocessor:${TAG}
     environment:
-      - "SPRING_PROFILES_ACTIVE={{profile}}"
+      - "SPRING_PROFILES_ACTIVE=${PROFILE}"
     volumes:
       - save:/home/cnb/
       - save-fs-storage:/home/cnb/files
@@ -72,9 +72,9 @@ services:
         max_attempts: 3
     logging: *loki-logging-jvm
   gateway:
-    image: ghcr.io/analysis-dev/api-gateway:{{project.version}}
+    image: ghcr.io/analysis-dev/api-gateway:${TAG}
     environment:
-      - "SPRING_PROFILES_ACTIVE={{profile}}"
+      - "SPRING_PROFILES_ACTIVE=${PROFILE}"
     ports:
       - "5300:5300"
     volumes:
@@ -84,7 +84,7 @@ services:
         - "prometheus-job=api-gateway"
     logging: *loki-logging-jvm
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v2.32.1
     user: root  # to access host's docker socket for service discovery, see https://groups.google.com/g/prometheus-users/c/EuEW0qRzXvg/m/0aqKh_ZABQAJ
     ports:
       - "9090:9090"
@@ -101,7 +101,7 @@ services:
         constraints:
           - "node.role==manager"
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:8.3.4
     ports:
       - "9100:3000"
     volumes:

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,11 @@
       ],
       "groupName": "Kotlin core dependencies",
       "groupSlug": "core-kotlin"
+    },
+    {
+      "managers": ["docker"],
+      "groupName": "all docker images",
+      "groupSlug": "all-docker-images"
     }
   ]
 }


### PR DESCRIPTION
* Rename docker-compose.yaml.template to docker-compose.yaml
* Update DockerStackConfiguration.kt
* Add explicit versions for 3rd party docker images
* Add renovate config for docker images

Initially it seemed to be a good idea to have complete control over compose file while generating it from a template. However, with standard docker way of doing it (via environment variables/environment files) we will be able to use standard tooling (syntax highlighting / format validation / auth-updates etc.). Fixing versions of 3rd party images should also improve stability of deployments.