### PR TITLE
infra: Cache save-cli version for 10 minutes in a file in build directory

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -24,11 +24,13 @@ jobs:
           arguments: |
             detektAll
       - name: Copy SARIF reports into a single directory
+        if: ${{ always() }}
         run: |
           mkdir -p build/detekt-sarif-reports
           i=0
           find . -name "detekt.sarif" | while read -r f; do echo "$f -> detekt-$i.sarif" && cp $f build/detekt-sarif-reports/detekt-$i.sarif || echo Cannot copy && echo Copied && i=$((i+1)); done
       - name: Upload SARIF to Github
+        if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: build/detekt-sarif-reports

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   detekt_check:
     runs-on: ubuntu-20.04
-    env:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
 
     steps:
       - uses: actions/checkout@v2.4.0
@@ -20,12 +18,17 @@ jobs:
         with:
           java-version: 11
           distribution: zulu
-      - uses: burrunan/gradle-cache-action@v1
+      - uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
-          # additional files to calculate key for dependency cache
-          gradle-dependencies-cache-key: |
-            buildSrc/**/Versions.kt
-      # Workaround for bug in gradle-cache-action + detekt
-      - name: Run gradle command
-        run: ./gradlew detektAll
+          arguments: |
+            detektAll
+      - name: Copy SARIF reports into a single directory
+        run: |
+          mkdir -p build/detekt-sarif-reports
+          i=0
+          find . -name "detekt.sarif" | while read -r f; do echo "$f -> detekt-$i.sarif" && cp $f build/detekt-sarif-reports/detekt-$i.sarif || echo Cannot copy && echo Copied && i=$((i+1)); done
+      - name: Upload SARIF to Github
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: build/detekt-sarif-reports

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,12 +56,14 @@ talaiot {
 }
 
 allprojects {
-    configureDiktat()
     configureDetekt()
     configurations.all {
         // if SNAPSHOT dependencies are used, refresh them periodically
         resolutionStrategy.cacheDynamicVersionsFor(10, TimeUnit.MINUTES)
     }
+}
+subprojects {
+    configureDiktat()
 }
 
 createStackDeployTask(profile)

--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DetektConfiguration.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DetektConfiguration.kt
@@ -21,6 +21,9 @@ fun Project.configureDetekt() {
         config = rootProject.files("detekt.yml")
         buildUponDefaultConfig = true
     }
+    tasks.withType<Detekt>().configureEach {
+        reports.sarif.required.set(true)
+    }
 }
 
 /**

--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DetektConfiguration.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DetektConfiguration.kt
@@ -19,6 +19,7 @@ fun Project.configureDetekt() {
     apply<DetektPlugin>()
     configure<DetektExtension> {
         config = rootProject.files("detekt.yml")
+        basePath = rootDir.canonicalPath
         buildUponDefaultConfig = true
     }
     tasks.withType<Detekt>().configureEach {

--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/VersioningConfiguration.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/VersioningConfiguration.kt
@@ -13,6 +13,8 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.the
 import java.net.URL
+import java.time.Duration
+import java.util.Properties
 
 /**
  * Configures reckon plugin for [this] project, should be applied for root project only
@@ -40,25 +42,43 @@ fun Project.configureVersioning() {
  */
 fun Project.versionForDockerImages() = version.toString().replace("+", "-")
 
+val Project.pathToSaveCliVersion get() = "${rootProject.buildDir}/save-cli.properties"
+
 /**
  * @return version of save-cli, either from project property, or from Versions, or latest
  */
 @Suppress("GENERIC_VARIABLE_WRONG_DECLARATION")
-fun Project.getSaveCliVersion(): String {
+fun Project.registerSaveCliVersionCheckTask() {
     val libs = the<LibrariesForLibs>()
     val saveCoreVersion = libs.versions.save.core.get()
-    return if (saveCoreVersion.endsWith("SNAPSHOT")) {
-        // try to get the required version of cli
-        findProperty("saveCliVersion") as String? ?: run {
-            // as fallback, use latest release to allow the project to build successfully
-            val latestRelease = ResourceGroovyMethods.getText(
-                URL("https://api.github.com/repos/analysis-dev/save/releases/latest")
-            )
-            (groovy.json.JsonSlurper().parseText(latestRelease) as Map<String, Any>)["tag_name"].let {
-                (it as String).trim('v')
-            }
+    tasks.register("getSaveCliVersion") {
+        val file = file(pathToSaveCliVersion)
+        outputs.file(file)
+        outputs.upToDateWhen {
+            // cache value of latest save-cli version for 10 minutes to keep request rate to Github reasonable
+            (System.currentTimeMillis() - file.lastModified()) < Duration.ofMinutes(10).toMillis()
         }
-    } else {
-        saveCoreVersion
+        doFirst {
+            val version = if (saveCoreVersion.endsWith("SNAPSHOT")) {
+                // try to get the required version of cli
+                findProperty("saveCliVersion") as String? ?: run {
+                    // as fallback, use latest release to allow the project to build successfully
+                    val latestRelease = ResourceGroovyMethods.getText(
+                        URL("https://api.github.com/repos/analysis-dev/save/releases/latest")
+                    )
+                    (groovy.json.JsonSlurper().parseText(latestRelease) as Map<String, Any>)["tag_name"].let {
+                        (it as String).trim('v')
+                    }
+                }
+            } else {
+                saveCoreVersion
+            }
+            file.writeText("""version=$version""")
+        }
     }
+}
+
+fun Project.readSaveCliVersion(): String {
+    val file = file(pathToSaveCliVersion)
+    return Properties().apply { load(file.reader()) }["version"] as String
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -569,7 +569,7 @@ potential-bugs:
   LateinitUsage:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    excludeAnnotatedProperties: []
+    ignoreAnnotated: []
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     excludes: ['**/resources/**']
@@ -662,7 +662,7 @@ style:
     active: true
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
-    excludeAnnotatedFunction: ['dagger.Provides']
+    ignoreAnnotated: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:
     excludes: ['**/resources/**']
     active: false
@@ -763,11 +763,11 @@ style:
   UnderscoresInNumericLiterals:
     excludes: ['**/resources/**']
     active: false
-    acceptableDecimalLength: 5
+    acceptableLength: 5
   UnnecessaryAbstractClass:
     excludes: ['**/resources/**']
     active: true
-    excludeAnnotatedClasses: ['dagger.Module']
+    ignoreAnnotated: ['dagger.Module']
   UnnecessaryAnnotationUseSiteTarget:
     excludes: ['**/resources/**']
     active: false
@@ -807,7 +807,7 @@ style:
   UseDataClass:
     excludes: ['**/resources/**']
     active: false
-    excludeAnnotatedClasses: []
+    ignoreAnnotated: []
     allowVars: false
   UseEmptyCounterpart:
     active: true

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -90,6 +90,7 @@ registerSaveCliVersionCheckTask()
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
+    dependsOn("getSaveCliVersion")
     inputs.file(pathToSaveCliVersion)
     inputs.property("project version", version.toString())
     outputs.file(versionsFile)

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -1,4 +1,6 @@
-import org.cqfn.save.buildutils.getSaveCliVersion
+import org.cqfn.save.buildutils.pathToSaveCliVersion
+import org.cqfn.save.buildutils.readSaveCliVersion
+import org.cqfn.save.buildutils.registerSaveCliVersionCheckTask
 
 plugins {
     kotlin("multiplatform")
@@ -84,15 +86,16 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinTest> {
 }
 
 // todo: this logic is duplicated between agent and frontend, can be moved to a shared plugin in buildSrc
+registerSaveCliVersionCheckTask()
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-    val saveCliVersion = getSaveCliVersion()
-    inputs.property("Version of save-cli", saveCliVersion)
+    inputs.file(pathToSaveCliVersion)
     inputs.property("project version", version.toString())
     outputs.file(versionsFile)
 
     doFirst {
+        val saveCliVersion = readSaveCliVersion()
         versionsFile.parentFile.mkdirs()
         versionsFile.writeText(
             """

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
@@ -99,7 +99,6 @@ class DownloadFilesController(
      * @return [Mono] with response
      * @throws ResponseStatusException if request is invalid or result cannot be returned
      */
-    @Suppress("ThrowsCount", "UnsafeCallOnNullableType")
     @PostMapping(value = ["/api/files/get-debug-info"])
     fun getDebugInfo(
         @RequestBody testExecutionDto: TestExecutionDto,

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
@@ -99,6 +99,7 @@ class DownloadFilesController(
      * @return [Mono] with response
      * @throws ResponseStatusException if request is invalid or result cannot be returned
      */
+    @Suppress("ThrowsCount", "UnsafeCallOnNullableType")
     @PostMapping(value = ["/api/files/get-debug-info"])
     fun getDebugInfo(
         @RequestBody testExecutionDto: TestExecutionDto,

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -63,9 +63,8 @@ val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     inputs.property("project version", version.toString())
     outputs.file(versionsFile)
 
-    val saveCliVersion = readSaveCliVersion()
-
     doFirst {
+        val saveCliVersion = readSaveCliVersion()
         versionsFile.parentFile.mkdirs()
         versionsFile.writeText(
             """

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.cqfn.save.buildutils.configureJacoco
 import org.cqfn.save.buildutils.configureSpringBoot
-import org.cqfn.save.buildutils.getSaveCliVersion
+import org.cqfn.save.buildutils.pathToSaveCliVersion
+import org.cqfn.save.buildutils.readSaveCliVersion
+import org.cqfn.save.buildutils.registerSaveCliVersionCheckTask
 
 import de.undercouch.gradle.tasks.download.Download
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -20,15 +22,19 @@ tasks.withType<KotlinCompile> {
 }
 
 // if required, file can be provided manually
-val saveCliVersion = getSaveCliVersion()
-@Suppress("RUN_IN_SCRIPT")
-if (!file("$buildDir/resources/main/save-$saveCliVersion-linuxX64.kexe").exists()) {
-    tasks.getByName("processResources").finalizedBy("downloadSaveCli")
-    tasks.register<Download>("downloadSaveCli") {
-        dependsOn("processResources")
-        src("https://github.com/analysis-dev/save/releases/download/v$saveCliVersion/save-$saveCliVersion-linuxX64.kexe")
-        dest("$buildDir/resources/main")
-    }
+registerSaveCliVersionCheckTask()
+tasks.getByName("processResources").finalizedBy("downloadSaveCli")
+tasks.register<Download>("downloadSaveCli") {
+    dependsOn("processResources")
+    dependsOn("getSaveCliVersion")
+    inputs.file(pathToSaveCliVersion)
+
+    src(KotlinClosure0(function = {
+        val saveCliVersion = readSaveCliVersion()
+        "https://github.com/analysis-dev/save/releases/download/v$saveCliVersion/save-$saveCliVersion-linuxX64.kexe"
+    }))
+    dest("$buildDir/resources/main")
+    overwrite(false)
 }
 
 tasks.withType<Test> {
@@ -52,10 +58,12 @@ configureJacoco()
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-    val saveCliVersion = getSaveCliVersion()
-    inputs.property("Version of save-cli", saveCliVersion)
+    dependsOn("getSaveCliVersion")
+    inputs.file(pathToSaveCliVersion)
     inputs.property("project version", version.toString())
     outputs.file(versionsFile)
+
+    val saveCliVersion = readSaveCliVersion()
 
     doFirst {
         versionsFile.parentFile.mkdirs()


### PR DESCRIPTION
* Cache save-cli version for 10 minutes in a file in build directory
* Do not apply default diktat configuration for root project (it was leading to diktat being applied on sarif4k files)
* Fix deprecated options in detekt.yml
* Enable SARIF reports for detekt and upload them to Github

Closes #536