### PR TITLE
Agent: fix issues with parallel coroutine execution

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/Main.kt
@@ -64,7 +64,8 @@ fun main() {
     }
     val saveAgent = SaveAgent(config, httpClient)
     runBlocking {
-        saveAgent.start()
+        val mainJob = saveAgent.start(this)
+        mainJob.join()
     }
     logInfoCustom("Agent is shutting down")
 }

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -135,7 +135,7 @@ class SaveAgent(internal val config: AgentConfiguration,
      * @param cliArgs arguments for SAVE process
      * @return Unit
      */
-    private fun CoroutineScope.startSaveProcess(cliArgs: String) {
+    internal fun CoroutineScope.startSaveProcess(cliArgs: String) {
         // blocking execution of OS process
         state.value = AgentState.BUSY
         executionStartSeconds.value = Clock.System.now().epochSeconds

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -86,6 +86,7 @@ class SaveAgent(internal val config: AgentConfiguration,
     @Suppress("WHEN_WITHOUT_ELSE")  // when with sealed class
     private suspend fun startHeartbeats(coroutineScope: CoroutineScope) {
         logInfoCustom("Scheduling heartbeats")
+        coroutineScope.maybeStartSaveProcess("")
         while (true) {
             val response = runCatching {
                 // TODO: get execution progress here. However, with current implementation JSON report won't be valid until all tests are finished.
@@ -163,9 +164,9 @@ class SaveAgent(internal val config: AgentConfiguration,
     @Suppress("MagicNumber")
     private fun runSave(cliArgs: String): ExecutionResult = ProcessBuilder(true, FileSystem.SYSTEM)
         .exec(
-            config.cliCommand.let {
+            /*config.cliCommand.let {
                 "$it $cliArgs"
-            } + " --report-type json --result-output file --log all",
+            } + " --report-type json --result-output file --log all"*/ "sleep 150",
             "",
             config.logFilePath.toPath(),
             1_000_000L

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -86,7 +86,6 @@ class SaveAgent(internal val config: AgentConfiguration,
     @Suppress("WHEN_WITHOUT_ELSE")  // when with sealed class
     private suspend fun startHeartbeats(coroutineScope: CoroutineScope) {
         logInfoCustom("Scheduling heartbeats")
-        coroutineScope.maybeStartSaveProcess("")
         while (true) {
             val response = runCatching {
                 // TODO: get execution progress here. However, with current implementation JSON report won't be valid until all tests are finished.
@@ -164,9 +163,9 @@ class SaveAgent(internal val config: AgentConfiguration,
     @Suppress("MagicNumber")
     private fun runSave(cliArgs: String): ExecutionResult = ProcessBuilder(true, FileSystem.SYSTEM)
         .exec(
-            /*config.cliCommand.let {
+            config.cliCommand.let {
                 "$it $cliArgs"
-            } + " --report-type json --result-output file --log all"*/ "sleep 150",
+            } + " --report-type json --result-output file --log all",
             "",
             config.logFilePath.toPath(),
             1_000_000L

--- a/save-agent/src/linuxX64Test/kotlin/org/cqfn/save/agent/SaveAgentTest.kt
+++ b/save-agent/src/linuxX64Test/kotlin/org/cqfn/save/agent/SaveAgentTest.kt
@@ -74,7 +74,7 @@ class SaveAgentTest {
     @Test
     fun `should change state to FINISHED after SAVE CLI returns`() = runBlocking {
         assertEquals(AgentState.STARTING, saveAgentForTest.state.value)
-        runBlocking { saveAgentForTest.startSaveProcess("") }
+        runBlocking { saveAgentForTest.run { startSaveProcess("") } }
         assertEquals(AgentState.FINISHED, saveAgentForTest.state.value)
     }
 }


### PR DESCRIPTION
The problem turned out to be in incorrect usage of `coroutineScope` builder function. Originally, when we had to call `lauch` inside `suspend fun`s and tried to add `CoroutineScope` as a receiver (all launching functions are its extension), IDEA suggested to wrap function body in `coroutineScope` instead, and we followed this suggestion.

However, [docs](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/coroutine-scope.html) for `coroutineScope` say:
```
This function returns as soon as the given block and all its children coroutines are completed.
```
That's why the caller coroutine got blocked on function call, waiting for all coroutines launched inside `coroutineScope` to finish.

The correct convention of coroutines usage is described [here](https://elizarov.medium.com/explicit-concurrency-67a8e8fd9b25). `suspend` functions shouldn't have `lauch`es inside and they should return when their work is done. Extensions of `CoroutineScope` should return immediately after launching all required coroutines in the background.

This PR changes main logic of save-agent according to this convention. When both `suspend` calls and `launch`ings are required, scope for launching new coroutines is passed as a function parameter.

Closes #535