### PR TITLE
Frontend: Remove message about cancellation of data fetching job on ExecutionView

### DIFF
--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/PagingControl.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/PagingControl.kt
@@ -213,6 +213,5 @@ private fun <D : Any> setPageIndexAndGoToPage(
     setPageIndex: StateSetter<Int>,
     index: Int
 ) {
-    setPageIndex(index)
     tableInstance.gotoPage(index)
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/PagingControl.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/PagingControl.kt
@@ -213,5 +213,6 @@ private fun <D : Any> setPageIndexAndGoToPage(
     setPageIndex: StateSetter<Int>,
     index: Int
 ) {
+    setPageIndex(index)
     tableInstance.gotoPage(index)
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
@@ -147,6 +147,9 @@ fun <D : Any> tableComponent(
                 setDataAccessException(e)
             }
         }
+    }
+    // this effect will be called only once, on component unmounting
+    useEffect(listOf<dynamic>()) {
         cleanup {
             if (scope.isActive) {
                 scope.cancel()

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
@@ -10,6 +10,7 @@ import org.cqfn.save.frontend.components.modal.errorModal
 import org.cqfn.save.frontend.utils.spread
 
 import kotlinext.js.jso
+import kotlinx.coroutines.CancellationException
 import react.PropsWithChildren
 import react.RBuilder
 import react.dom.RDOMBuilder
@@ -142,14 +143,14 @@ fun <D : Any> tableComponent(
         scope.launch {
             try {
                 setData(getData(tableInstance.state.pageIndex, tableInstance.state.pageSize))
+            } catch (e: CancellationException) {
+                // this means, that view is re-rendering while network request was still in progress
+                // no need to display an error message in this case
             } catch (e: Exception) {
                 setIsModalOpen(true)
                 setDataAccessException(e)
             }
         }
-    }
-    // this effect will be called only once, on component unmounting
-    useEffect(listOf<dynamic>()) {
         cleanup {
             if (scope.isActive) {
                 scope.cancel()

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
@@ -10,7 +10,6 @@ import org.cqfn.save.frontend.components.modal.errorModal
 import org.cqfn.save.frontend.utils.spread
 
 import kotlinext.js.jso
-import kotlinx.coroutines.CancellationException
 import react.PropsWithChildren
 import react.RBuilder
 import react.dom.RDOMBuilder
@@ -38,6 +37,7 @@ import react.useMemo
 import react.useState
 
 import kotlin.js.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
@@ -41,7 +41,6 @@ import kotlin.js.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -123,11 +122,9 @@ fun <D : Any> tableComponent(
 
     useEffect(arrayOf<dynamic>(tableInstance.state.pageSize, pageCount)) {
         if (useServerPaging) {
-            val pageCountDeferred = scope.async {
-                getPageCount!!.invoke(tableInstance.state.pageSize)
-            }
-            pageCountDeferred.invokeOnCompletion {
-                setPageCount(pageCountDeferred.getCompleted())
+            scope.launch {
+                val newPageCount = getPageCount!!.invoke(tableInstance.state.pageSize)
+                setPageCount(newPageCount)
             }
         }
     }


### PR DESCRIPTION
This is a fix for a regression after #561: every time the table on the ExecutionView renders, there is an error message about job cancellation. It actually happens because the component re-renders, while the previous request is still in progress. This may be an indication of a problem with multiple unnecessary re-renders of table component, but also shouldn't be visible to the users, because eventually data is fetched without problems.

Also, there is no need to call `setPageCount` from `invokeOnCompletion`.