### PR TITLE
Frontend: Fix recreation of functional components

### DIFF
--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -32,6 +32,12 @@ import kotlinx.html.id
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
+private val scrollToTopButton = scrollToTopButton()
+
+private val topBar = topBar()
+
+private val testExecutionDetailsView = testExecutionDetailsView()
+
 /**
  * Top-level state of the whole App
  */
@@ -76,7 +82,7 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
         HashRouter {
             div("d-flex flex-column") {
                 attrs.id = "content-wrapper"
-                child(topBar()) {
+                child(topBar) {
                     attrs {
                         userInfo = state.userInfo
                     }
@@ -171,7 +177,7 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
                                 // Since testFilePath can represent the nested path, we catch it as *
                                 path = "/:owner/:name/history/execution/:executionId/details/:testSuiteName/:pluginName/*"
                                 element = buildElement {
-                                    child(testExecutionDetailsView()) {}
+                                    child(testExecutionDetailsView) {}
                                 }
                             }
                         }
@@ -189,7 +195,7 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
                 child(Footer::class) {}
             }
         }
-        child(scrollToTopButton()) {}
+        child(scrollToTopButton) {}
     }
 }
 

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -54,6 +54,26 @@ external interface AppState : State {
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 class App : ComponentWithScope<PropsWithChildren, AppState>() {
+    private val projectView: FC<Props> = withRouter { _, params ->
+        child(ProjectView::class) {
+            attrs.name = params["name"]!!
+            attrs.owner = params["owner"]!!
+        }
+    }
+    private val historyView: FC<Props> = withRouter { _, params ->
+        child(HistoryView::class) {
+            attrs.name = params["name"]!!
+            attrs.organizationName = params["owner"]!!
+        }
+    }
+    private val executionView: FC<Props> = withRouter { location, params ->
+        child(ExecutionView::class) {
+            attrs.executionId = params["executionId"]!!
+            attrs.status = URLSearchParams(location.search).get("status")?.let(
+                TestResultStatus::valueOf
+            )
+        }
+    }
     init {
         state.userInfo = null
     }
@@ -132,12 +152,7 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
                             attrs {
                                 path = "/:owner/:name"
                                 element = buildElement {
-                                    child(withRouter { _, params ->
-                                        child(ProjectView::class) {
-                                            attrs.name = params["name"]!!
-                                            attrs.owner = params["owner"]!!
-                                        }
-                                    })
+                                    child(projectView)
                                 }
                             }
                         }
@@ -146,12 +161,7 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
                             attrs {
                                 path = "/:owner/:name/history"
                                 element = buildElement {
-                                    child(withRouter { _, params ->
-                                        child(HistoryView::class) {
-                                            attrs.name = params["name"]!!
-                                            attrs.organizationName = params["owner"]!!
-                                        }
-                                    })
+                                    child(historyView)
                                 }
                             }
                         }
@@ -160,14 +170,7 @@ class App : ComponentWithScope<PropsWithChildren, AppState>() {
                             attrs {
                                 path = "/:owner/:name/history/execution/:executionId"
                                 element = buildElement {
-                                    child(withRouter { location, params ->
-                                        child(ExecutionView::class) {
-                                            attrs.executionId = params["executionId"]!!
-                                            attrs.status = URLSearchParams(location.search).get("status")?.let(
-                                                TestResultStatus::valueOf
-                                            )
-                                        }
-                                    })
+                                    child(executionView)
                                 }
                             }
                         }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/ExecutionStatistics.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/ExecutionStatistics.kt
@@ -123,10 +123,10 @@ fun executionStatistics(classes: String = "") = fc<ExecutionStatisticsProps> { p
 /**
  * A component which displays a GIF if tests not found
  *
- * @param count tests for execution
  * @return a functional react component
  */
-fun executionTestsNotFound(count: Int?) = fc<ExecutionStatisticsProps> { props ->
+fun executionTestsNotFound() = fc<ExecutionStatisticsProps> { props ->
+    val count = props.countTests
     if (count == 0 && props.executionDto?.status != ExecutionStatus.PENDING) {
         div("d-flex justify-content-center") {
             img(src = "img/sad_cat.gif") {}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
@@ -83,7 +83,7 @@ external interface UploaderProps : PropsWithChildren {
     /**
      * Flag to handle uploading a file
      */
-    var isUploading: Boolean
+    var isUploading: Boolean?
 }
 
 /**
@@ -172,7 +172,7 @@ fun fileUploader(
                 }
 
                 div("progress") {
-                    attrs.hidden = !props.isUploading
+                    attrs.hidden = !(props.isUploading ?: false)
                     div("progress-bar progress-bar-striped progress-bar-animated") {
                         attrs["style"] = jso<CSSProperties> {
                             width = if (props.suiteByteSize != 0L) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
@@ -23,6 +23,56 @@ import kotlinx.html.ButtonType
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 class CollectionView : AbstractView<PropsWithChildren, State>(false) {
+    @Suppress("MAGIC_NUMBER")
+    private val projectsTable = tableComponent(
+        columns = columns<Project> {
+            column(id = "owner", header = "Project Owner", { organization.name }) {
+                buildElement {
+                    td {
+                        // FixMe: temporary disable links, until we will make a beat
+                        // a(href = "#/${it.value}") {
+                        +it.value!!
+                        // }
+                    }
+                }
+            }
+            column(id = "name", header = "Evaluated Tool", { name }) {
+                buildElement {
+                    td {
+                        a(href = "#/${it.row.original.organization.name}/${it.value}") { +it.value }
+                        privacySpan(it.row.original)
+                    }
+                }
+            }
+            column(id = "passed", header = "Description") {
+                buildElement {
+                    td {
+                        +(it.value.description ?: "Description not provided")
+                    }
+                }
+            }
+            column(id = "rating", header = "Contest Rating") {
+                buildElement {
+                    td {
+                        +"0"
+                    }
+                }
+            }
+        },
+        initialPageSize = 10,
+        useServerPaging = false,
+        usePageSelection = false,
+    ) { _, _ ->
+        get(
+            url = "$apiUrl/projects/not-deleted",
+            headers = Headers().also {
+                it.set("Accept", "application/json")
+            },
+        )
+            .unsafeMap {
+                it.decodeFromJsonString<Array<Project>>()
+            }
+    }
     @Suppress(
         "EMPTY_BLOCK_STRUCTURE_ERROR",
         "TOO_LONG_FUNCTION",
@@ -37,54 +87,6 @@ class CollectionView : AbstractView<PropsWithChildren, State>(false) {
                 }
             }
         }
-        child(tableComponent(
-            columns = columns<Project> {
-                column(id = "owner", header = "Project Owner", { organization.name }) {
-                    buildElement {
-                        td {
-                            // FixMe: temporary disable links, until we will make a beat
-                            // a(href = "#/${it.value}") {
-                            +it.value!!
-                            // }
-                        }
-                    }
-                }
-                column(id = "name", header = "Evaluated Tool", { name }) {
-                    buildElement {
-                        td {
-                            a(href = "#/${it.row.original.organization.name}/${it.value}") { +it.value }
-                            privacySpan(it.row.original)
-                        }
-                    }
-                }
-                column(id = "passed", header = "Description") {
-                    buildElement {
-                        td {
-                            +(it.value.description ?: "Description not provided")
-                        }
-                    }
-                }
-                column(id = "rating", header = "Contest Rating") {
-                    buildElement {
-                        td {
-                            +"0"
-                        }
-                    }
-                }
-            },
-            initialPageSize = 10,
-            useServerPaging = false,
-            usePageSelection = false,
-        ) { _, _ ->
-            get(
-                url = "$apiUrl/projects/not-deleted",
-                headers = Headers().also {
-                    it.set("Accept", "application/json")
-                },
-            )
-                .unsafeMap {
-                    it.decodeFromJsonString<Array<Project>>()
-                }
-        }) { }
+        child(projectsTable) { }
     }
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -92,6 +92,248 @@ external interface ExecutionState : State {
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
+    private val executionStatistics = executionStatistics("mr-auto")
+    private val executionTestsNotFound = executionTestsNotFound()
+    private val testExecutionFiltersRow = testExecutionFiltersRow(
+        initialValueStatus = state.status?.name ?: ANY,
+        initialValueTestSuite = state.testSuite ?: "",
+        onChangeStatus = { value ->
+            if (value == "ANY") {
+                setState {
+                    status = null
+                }
+            } else {
+                setState {
+                    status = TestResultStatus.valueOf(value)
+                }
+            }
+        },
+        onChangeTestSuite = { testSuiteValue ->
+            if (testSuiteValue == "") {
+                setState {
+                    testSuite = null
+                }
+            } else {
+                setState {
+                    testSuite = testSuiteValue
+                }
+            }
+        }
+    )
+
+    @Suppress("MAGIC_NUMBER")
+    private val testExecutionsTable = tableComponent(
+        columns = columns<TestExecutionDto> {
+            column(id = "index", header = "#") {
+                buildElement {
+                    td {
+                        +"${it.row.index + 1 + it.state.pageIndex * it.state.pageSize}"
+                    }
+                }
+            }
+            column(id = "startTime", header = "Start time", { startTimeSeconds }) {
+                buildElement {
+                    td {
+                        +"${
+                            it.value?.let { Instant.fromEpochSeconds(it, 0) }
+                            ?: "Running"
+                        }"
+                    }
+                }
+            }
+            column(id = "endTime", header = "End time", { endTimeSeconds }) {
+                buildElement {
+                    td {
+                        +"${
+                            it.value?.let { Instant.fromEpochSeconds(it, 0) }
+                            ?: "Running"
+                        }"
+                    }
+                }
+            }
+            column(id = "status", header = "Status", { status.name }) {
+                buildElement {
+                    td {
+                        +it.value
+                    }
+                }
+            }
+            column(id = "missing", header = "Missing", { missingWarnings }) {
+                buildElement {
+                    td {
+                        +"${it.value ?: ""}"
+                    }
+                }
+            }
+            column(id = "matched", header = "Matched", { matchedWarnings }) {
+                buildElement {
+                    td {
+                        +"${it.value ?: ""}"
+                    }
+                }
+            }
+            column(id = "path", header = "Test file path") { cellProps ->
+                buildElement {
+                    td {
+                        spread(cellProps.row.getToggleRowExpandedProps())
+
+                        attrs["style"] = jso<CSSProperties> {
+                            textDecoration = "underline grey".unsafeCast<TextDecoration>()
+                        }
+
+                        val testName = cellProps.value.filePath
+                        val shortTestName = if (testName.length > 35) {
+                            testName.take(15) + " ... " + testName.takeLast(15)
+                        } else {
+                            testName
+                        }
+
+                        +shortTestName
+
+                        attrs.onClickFunction = {
+                            scope.launch {
+                                val te = cellProps.value
+                                val trdi = getDebugInfoFor(te)
+                                if (trdi.ok) {
+                                    cellProps.row.original.asDynamic().debugInfo = trdi.decodeFromJsonString<TestResultDebugInfo>()
+                                }
+                                cellProps.row.toggleRowExpanded()
+                            }
+                        }
+                    }
+                }
+            }
+            column(id = "plugin", header = "Plugin type", { pluginName }) {
+                buildElement {
+                    td {
+                        +it.value
+                    }
+                }
+            }
+            column(id = "suiteName", header = "Test suite", { testSuiteName }) {
+                buildElement {
+                    td {
+                        +"${it.value}"
+                    }
+                }
+            }
+            column(id = "tags", header = "Tags") {
+                buildElement {
+                    td {
+                        +"${it.value.tags}"
+                    }
+                }
+            }
+            column(id = "agentId", header = "Agent ID") {
+                buildElement {
+                    td {
+                        +"${it.value.agentContainerId}".takeLast(12)
+                    }
+                }
+            }
+        },
+        useServerPaging = true,
+        usePageSelection = true,
+        plugins = arrayOf(
+            useFilters,
+            useSortBy,
+            useExpanded,
+            usePagination,
+        ),
+        renderExpandedRow = { tableInstance, row ->
+            // todo: placeholder before, render data once it's available
+            val trdi = row.original.asDynamic().debugInfo as TestResultDebugInfo?
+            trdi?.let {
+                child(testStatusComponent(trdi, tableInstance)) {
+                    // attrs.key = trdi.testResultLocation.toString()
+                }
+            }
+                ?: run {
+                    tr {
+                        td {
+                            attrs.colSpan = "${tableInstance.columns.size}"
+                            +"Debug info not available yet for this test execution"
+                        }
+                    }
+                }
+        },
+        additionalOptions = {
+            this.asDynamic().manualFilters = true
+        },
+        commonHeader = { tableInstance ->
+            tr {
+                th {
+                    attrs.colSpan = "${tableInstance.columns.size}"
+                    child(testExecutionFiltersRow)
+                }
+            }
+        },
+        getPageCount = { pageSize ->
+            val status = state.status?.let {
+                "&status=${state.status}"
+            }
+                ?: run {
+                    ""
+                }
+            val testSuite = state.testSuite?.let {
+                "&testSuite=${state.testSuite}"
+            }
+                ?: run {
+                    ""
+                }
+            val count: Int = get(
+                url = "$apiUrl/testExecution/count?executionId=${props.executionId}$status$testSuite",
+                headers = Headers().also {
+                    it.set("Accept", "application/json")
+                },
+            )
+                .json()
+                .await()
+                .unsafeCast<Int>()
+            count / pageSize + 1
+        },
+        getRowProps = { row ->
+            val color = when (row.original.status) {
+                TestResultStatus.FAILED -> Colors.RED
+                TestResultStatus.IGNORED -> Colors.GOLD
+                TestResultStatus.READY_FOR_TESTING, TestResultStatus.RUNNING -> Colors.GREY
+                TestResultStatus.INTERNAL_ERROR, TestResultStatus.TEST_ERROR -> Colors.DARK_RED
+                TestResultStatus.PASSED -> Colors.GREEN
+            }
+            jso {
+                style = jso {
+                    background = color.value.unsafeCast<Background>()
+                }
+            }
+        }
+    ) { page, size ->
+        val status = state.status?.let {
+            "&status=${state.status}"
+        }
+            ?: run {
+                ""
+            }
+        val testSuite = state.testSuite?.let {
+            "&testSuite=${state.testSuite}"
+        }
+            ?: run {
+                ""
+            }
+        get(
+            url = "$apiUrl/testExecutions?executionId=${props.executionId}&page=$page&size=$size$status$testSuite",
+            headers = Headers().apply {
+                set("Accept", "application/json")
+            },
+        )
+            .unsafeMap {
+                Json.decodeFromString<Array<TestExecutionDto>>(
+                    it.text().await()
+                )
+            }
+            .apply {
+                asDynamic().debugInfo = null
+            }
+    }
     init {
         state.executionDto = null
         state.status = null
@@ -151,7 +393,7 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
                     }
                 }
 
-                child(executionStatistics("mr-auto")) {
+                child(executionStatistics) {
                     attrs.executionDto = state.executionDto
                     attrs.countTests = state.countTests
                 }
@@ -186,222 +428,10 @@ class ExecutionView : AbstractView<ExecutionProps, ExecutionState>(false) {
         }
 
         // fixme: table is rendered twice because of state change when `executionDto` is fetched
-        child(tableComponent(
-            columns = columns<TestExecutionDto> {
-                column(id = "index", header = "#") {
-                    buildElement {
-                        td {
-                            +"${it.row.index + 1 + it.state.pageIndex * it.state.pageSize}"
-                        }
-                    }
-                }
-                column(id = "startTime", header = "Start time", { startTimeSeconds }) {
-                    buildElement {
-                        td {
-                            +"${
-                                it.value?.let { Instant.fromEpochSeconds(it, 0) }
-                                ?: "Running"
-                            }"
-                        }
-                    }
-                }
-                column(id = "endTime", header = "End time", { endTimeSeconds }) {
-                    buildElement {
-                        td {
-                            +"${
-                                it.value?.let { Instant.fromEpochSeconds(it, 0) }
-                                ?: "Running"
-                            }"
-                        }
-                    }
-                }
-                column(id = "status", header = "Status", { status.name }) {
-                    buildElement {
-                        td {
-                            +it.value
-                        }
-                    }
-                }
-                column(id = "missing", header = "Missing", { missingWarnings }) {
-                    buildElement {
-                        td {
-                            +"${it.value ?: ""}"
-                        }
-                    }
-                }
-                column(id = "matched", header = "Matched", { matchedWarnings }) {
-                    buildElement {
-                        td {
-                            +"${it.value ?: ""}"
-                        }
-                    }
-                }
-                column(id = "path", header = "Test file path") { cellProps ->
-                    buildElement {
-                        td {
-                            spread(cellProps.row.getToggleRowExpandedProps())
-
-                            attrs["style"] = jso<CSSProperties> {
-                                textDecoration = "underline grey".unsafeCast<TextDecoration>()
-                            }
-
-                            val testName = cellProps.value.filePath
-                            val shortTestName = if (testName.length > 35) {
-                                testName.take(15) + " ... " + testName.takeLast(15)
-                            } else {
-                                testName
-                            }
-
-                            +shortTestName
-
-                            attrs.onClickFunction = {
-                                scope.launch {
-                                    val te = cellProps.value
-                                    val trdi = getDebugInfoFor(te)
-                                    if (trdi.ok) {
-                                        cellProps.row.original.asDynamic().debugInfo = trdi.decodeFromJsonString<TestResultDebugInfo>()
-                                    }
-                                    cellProps.row.toggleRowExpanded()
-                                }
-                            }
-                        }
-                    }
-                }
-                column(id = "plugin", header = "Plugin type", { pluginName }) {
-                    buildElement {
-                        td {
-                            +it.value
-                        }
-                    }
-                }
-                column(id = "suiteName", header = "Test suite", { testSuiteName }) {
-                    buildElement {
-                        td {
-                            +"${it.value}"
-                        }
-                    }
-                }
-                column(id = "tags", header = "Tags") {
-                    buildElement {
-                        td {
-                            +"${it.value.tags}"
-                        }
-                    }
-                }
-                column(id = "agentId", header = "Agent ID") {
-                    buildElement {
-                        td {
-                            +"${it.value.agentContainerId}".takeLast(12)
-                        }
-                    }
-                }
-            },
-            useServerPaging = true,
-            usePageSelection = true,
-            plugins = arrayOf(
-                useFilters,
-                useSortBy,
-                useExpanded,
-                usePagination,
-            ),
-            renderExpandedRow = { tableInstance, row ->
-                // todo: placeholder before, render data once it's available
-                val trdi = row.original.asDynamic().debugInfo as TestResultDebugInfo?
-                if (trdi != null) {
-                    child(testStatusComponent(trdi, tableInstance))
-                } else {
-                    tr {
-                        td {
-                            attrs.colSpan = "${tableInstance.columns.size}"
-                            +"Debug info not available yet for this test execution"
-                        }
-                    }
-                }
-            },
-            additionalOptions = {
-                this.asDynamic().manualFilters = true
-            },
-            commonHeader = { tableInstance ->
-                tr {
-                    th {
-                        attrs.colSpan = "${tableInstance.columns.size}"
-                        child(testExecutionFiltersRow(
-                            initialValueStatus = state.status?.name ?: ANY,
-                            initialValueTestSuite = state.testSuite ?: "",
-                            onChangeStatus = { value ->
-                                if (value == "ANY") {
-                                    setState {
-                                        status = null
-                                    }
-                                } else {
-                                    setState {
-                                        status = TestResultStatus.valueOf(value)
-                                    }
-                                }
-                            },
-                            onChangeTestSuite = { testSuiteValue ->
-                                if (testSuiteValue == "") {
-                                    setState {
-                                        testSuite = null
-                                    }
-                                } else {
-                                    setState {
-                                        testSuite = testSuiteValue
-                                    }
-                                }
-                            }
-                        ))
-                    }
-                }
-            },
-            getPageCount = { pageSize ->
-                val status = if (state.status != null) "&status=${state.status}" else ""
-                val testSuite = if (state.testSuite != null) "&testSuite=${state.testSuite}" else ""
-                val count: Int = get(
-                    url = "$apiUrl/testExecution/count?executionId=${props.executionId}$status$testSuite",
-                    headers = Headers().also {
-                        it.set("Accept", "application/json")
-                    },
-                )
-                    .json()
-                    .await()
-                    .unsafeCast<Int>()
-                count / pageSize + 1
-            },
-            getRowProps = { row ->
-                val color = when (row.original.status) {
-                    TestResultStatus.FAILED -> Colors.RED
-                    TestResultStatus.IGNORED -> Colors.GOLD
-                    TestResultStatus.READY_FOR_TESTING, TestResultStatus.RUNNING -> Colors.GREY
-                    TestResultStatus.INTERNAL_ERROR, TestResultStatus.TEST_ERROR -> Colors.DARK_RED
-                    TestResultStatus.PASSED -> Colors.GREEN
-                }
-                jso {
-                    style = jso {
-                        background = color.value.unsafeCast<Background>()
-                    }
-                }
-            }
-        ) { page, size ->
-            val status = if (state.status != null) "&status=${state.status}" else ""
-            val testSuite = if (state.testSuite != null) "&testSuite=${state.testSuite}" else ""
-            get(
-                url = "$apiUrl/testExecutions?executionId=${props.executionId}&page=$page&size=$size$status$testSuite",
-                headers = Headers().apply {
-                    set("Accept", "application/json")
-                },
-            )
-                .unsafeMap {
-                    Json.decodeFromString<Array<TestExecutionDto>>(
-                        it.text().await()
-                    )
-                }
-                .apply {
-                    asDynamic().debugInfo = null
-                }
-        }) { }
-        child(executionTestsNotFound(state.countTests)) {
+        child(testExecutionsTable)
+        child(executionTestsNotFound) {
             attrs.executionDto = state.executionDto
+            attrs.countTests = state.countTests
         }
     }
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/HistoryView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/HistoryView.kt
@@ -8,6 +8,9 @@ import org.cqfn.save.domain.TestResultStatus
 import org.cqfn.save.execution.ExecutionDto
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.frontend.components.tables.tableComponent
+import org.cqfn.save.frontend.externals.fontawesome.faCheck
+import org.cqfn.save.frontend.externals.fontawesome.faExclamationTriangle
+import org.cqfn.save.frontend.externals.fontawesome.faSpinner
 import org.cqfn.save.frontend.externals.fontawesome.faTrashAlt
 import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
 import org.cqfn.save.frontend.themes.Colors
@@ -110,13 +113,13 @@ class HistoryView : AbstractView<HistoryProps, HistoryViewState>(false) {
         columns = columns<ExecutionDto> {
             column("result", "", { status }) { cellProps ->
                 val result = when (cellProps.row.original.status) {
-                    ExecutionStatus.ERROR -> ResultColorAndIcon("text-danger", "exclamation-triangle")
-                    ExecutionStatus.PENDING -> ResultColorAndIcon("text-success", "spinner")
-                    ExecutionStatus.RUNNING -> ResultColorAndIcon("text-success", "spinner")
+                    ExecutionStatus.ERROR -> ResultColorAndIcon("text-danger", faExclamationTriangle)
+                    ExecutionStatus.PENDING -> ResultColorAndIcon("text-success", faSpinner)
+                    ExecutionStatus.RUNNING -> ResultColorAndIcon("text-success", faSpinner)
                     ExecutionStatus.FINISHED -> if (cellProps.row.original.failedTests != 0L) {
-                        ResultColorAndIcon("text-danger", "exclamation-triangle")
+                        ResultColorAndIcon("text-danger", faExclamationTriangle)
                     } else {
-                        ResultColorAndIcon("text-success", "check")
+                        ResultColorAndIcon("text-success", faCheck)
                     }
                 }
                 buildElement {
@@ -339,5 +342,5 @@ class HistoryView : AbstractView<HistoryProps, HistoryViewState>(false) {
      * @property resColor
      * @property resIcon
      */
-    private data class ResultColorAndIcon(val resColor: String, val resIcon: String)
+    private data class ResultColorAndIcon(val resColor: String, val resIcon: dynamic)
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/HistoryView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/HistoryView.kt
@@ -105,11 +105,132 @@ external interface HistoryViewState : State {
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 class HistoryView : AbstractView<HistoryProps, HistoryViewState>(false) {
+    @Suppress("MAGIC_NUMBER")
+    private val executionsTable = tableComponent(
+        columns = columns<ExecutionDto> {
+            column("result", "", { status }) { cellProps ->
+                val result = when (cellProps.row.original.status) {
+                    ExecutionStatus.ERROR -> ResultColorAndIcon("text-danger", "exclamation-triangle")
+                    ExecutionStatus.PENDING -> ResultColorAndIcon("text-success", "spinner")
+                    ExecutionStatus.RUNNING -> ResultColorAndIcon("text-success", "spinner")
+                    ExecutionStatus.FINISHED -> if (cellProps.row.original.failedTests != 0L) {
+                        ResultColorAndIcon("text-danger", "exclamation-triangle")
+                    } else {
+                        ResultColorAndIcon("text-success", "check")
+                    }
+                }
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(cellProps.row.original.id, null)) {
+                            fontAwesomeIcon(result.resIcon, classes = result.resColor)
+                        }
+                    }
+                }
+            }
+            column("status", "Status", { status }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, null)) {
+                            +"${it.value}"
+                        }
+                    }
+                }
+            }
+            column("startDate", "Start time", { startTime }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, null)) {
+                            +(formattingDate(it.value) ?: "Starting")
+                        }
+                    }
+                }
+            }
+            column("endDate", "End time", { endTime }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, null)) {
+                            +(formattingDate(it.value) ?: "Starting")
+                        }
+                    }
+                }
+            }
+            column("running", "Running", { runningTests }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, TestResultStatus.RUNNING)) {
+                            +"${it.value}"
+                        }
+                    }
+                }
+            }
+            column("passed", "Passed", { passedTests }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, TestResultStatus.PASSED)) {
+                            +"${it.value}"
+                        }
+                    }
+                }
+            }
+            column("failed", "Failed", { failedTests }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, TestResultStatus.FAILED)) {
+                            +"${it.value}"
+                        }
+                    }
+                }
+            }
+            column("skipped", "Skipped", { skippedTests }) {
+                buildElement {
+                    td {
+                        a(href = getHrefToExecution(it.row.original.id, TestResultStatus.IGNORED)) {
+                            +"${it.value}"
+                        }
+                    }
+                }
+            }
+            column("checkBox", "") { cellProps ->
+                buildElement {
+                    td {
+                        button(type = ButtonType.button, classes = "btn btn-small") {
+                            fontAwesomeIcon(icon = faTrashAlt, classes = "trash-alt")
+                            attrs.onClickFunction = {
+                                deleteExecution(cellProps.value.id)
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        getRowProps = { row ->
+            val color = when (row.original.status) {
+                ExecutionStatus.ERROR -> Colors.RED
+                ExecutionStatus.PENDING -> Colors.GREY
+                ExecutionStatus.RUNNING -> Colors.GREY
+                ExecutionStatus.FINISHED -> if (row.original.failedTests != 0L) Colors.DARK_RED else Colors.GREEN
+            }
+            jso {
+                style = jso {
+                    background = color.value.unsafeCast<Background>()
+                }
+            }
+        }
+    ) { _, _ ->
+        get(
+            url = "$apiUrl/executionDtoList?name=${props.name}&organizationName=${props.organizationName}",
+            headers = Headers().also {
+                it.set("Accept", "application/json")
+            },
+        )
+            .unsafeMap {
+                it.decodeFromJsonString<Array<ExecutionDto>>()
+            }
+    }
     private lateinit var responseFromDeleteExecutions: Response
 
     @Suppress(
         "TOO_LONG_FUNCTION",
-        "MAGIC_NUMBER",
         "ForbiddenComment",
         "LongMethod",
     )
@@ -136,129 +257,7 @@ class HistoryView : AbstractView<HistoryProps, HistoryViewState>(false) {
                 +"Delete all executions"
             }
         }
-        child(tableComponent(
-            columns = columns<ExecutionDto> {
-                column("result", "", { status }) { cellProps ->
-                    val result = when (cellProps.row.original.status) {
-                        ExecutionStatus.ERROR -> ResultColorAndIcon("text-danger", "exclamation-triangle")
-                        ExecutionStatus.PENDING -> ResultColorAndIcon("text-success", "spinner")
-                        ExecutionStatus.RUNNING -> ResultColorAndIcon("text-success", "spinner")
-                        ExecutionStatus.FINISHED -> if (cellProps.row.original.failedTests != 0L) {
-                            ResultColorAndIcon("text-danger", "exclamation-triangle")
-                        } else {
-                            ResultColorAndIcon("text-success", "check")
-                        }
-                    }
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(cellProps.row.original.id, null)) {
-                                fontAwesomeIcon(result.resIcon, classes = result.resColor)
-                            }
-                        }
-                    }
-                }
-                column("status", "Status", { status }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, null)) {
-                                +"${it.value}"
-                            }
-                        }
-                    }
-                }
-                column("startDate", "Start time", { startTime }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, null)) {
-                                +(formattingDate(it.value) ?: "Starting")
-                            }
-                        }
-                    }
-                }
-                column("endDate", "End time", { endTime }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, null)) {
-                                +(formattingDate(it.value) ?: "Starting")
-                            }
-                        }
-                    }
-                }
-                column("running", "Running", { runningTests }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, TestResultStatus.RUNNING)) {
-                                +"${it.value}"
-                            }
-                        }
-                    }
-                }
-                column("passed", "Passed", { passedTests }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, TestResultStatus.PASSED)) {
-                                +"${it.value}"
-                            }
-                        }
-                    }
-                }
-                column("failed", "Failed", { failedTests }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, TestResultStatus.FAILED)) {
-                                +"${it.value}"
-                            }
-                        }
-                    }
-                }
-                column("skipped", "Skipped", { skippedTests }) {
-                    buildElement {
-                        td {
-                            a(href = getHrefToExecution(it.row.original.id, TestResultStatus.IGNORED)) {
-                                +"${it.value}"
-                            }
-                        }
-                    }
-                }
-                column("checkBox", "") { cellProps ->
-                    buildElement {
-                        td {
-                            button(type = ButtonType.button, classes = "btn btn-small") {
-                                fontAwesomeIcon(icon = faTrashAlt, classes = "trash-alt")
-                                attrs.onClickFunction = {
-                                    deleteExecution(cellProps.value.id)
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            getRowProps = { row ->
-                val color = when (row.original.status) {
-                    ExecutionStatus.ERROR -> Colors.RED
-                    ExecutionStatus.PENDING -> Colors.GREY
-                    ExecutionStatus.RUNNING -> Colors.GREY
-                    ExecutionStatus.FINISHED -> if (row.original.failedTests != 0L) Colors.DARK_RED else Colors.GREEN
-                }
-                jso {
-                    style = jso {
-                        background = color.value.unsafeCast<Background>()
-                    }
-                }
-            }
-        ) { _, _ ->
-            get(
-                url = "$apiUrl/executionDtoList?name=${props.name}&organizationName=${props.organizationName}",
-                headers = Headers().also {
-                    it.set("Accept", "application/json")
-                    it.set("Content-Type", "application/json")
-                },
-            )
-                .unsafeMap {
-                    it.decodeFromJsonString<Array<ExecutionDto>>()
-                }
-        }
-        ) {
+        child(executionsTable) {
             attrs.tableHeader = "Executions details"
         }
     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -174,7 +174,7 @@ external interface ProjectViewState : State {
     /**
      * Flag to handle uploading a file
      */
-    var isUploading: Boolean
+    var isUploading: Boolean?
 }
 
 /**
@@ -206,6 +206,200 @@ class ProjectView : AbstractView<ProjectExecutionRouteProps, ProjectViewState>(f
         "Description: " to "",
         "Tested tool Url: " to "",
     )
+    private val testResourcesSelection = testResourcesSelection(
+        updateGitUrlFromInputField = {
+            console.log("updateGitUrlFromInputField with ${it.target}")
+            it.preventDefault()
+            setState {
+                gitUrlFromInputField = (it.target as HTMLInputElement).value
+            }
+        },
+        updateGitBranchOrCommitInputField = {
+            setState {
+                gitBranchOrCommitFromInputField = (it.target as HTMLInputElement).value
+            }
+        },
+        updateTestRootPath = {
+            setState {
+                testRootPath = (it.target as HTMLInputElement).value
+            }
+        },
+        setTestRootPathFromHistory = {
+            setState {
+                testRootPath = it
+            }
+        },
+        setExecCmd = {
+            setState {
+                execCmd = (it.target as HTMLInputElement).value
+            }
+        },
+        setBatchSize = {
+            setState {
+                batchSizeForAnalyzer = (it.target as HTMLInputElement).value
+            }
+        },
+        setSelectedLanguageForStandardTests = {
+            setState {
+                selectedLanguageForStandardTests = it
+            }
+        }
+    )
+    private val projectInfoCard = cardComponent(isBordered = true, hasBg = true) {
+        val newProjectInformation: MutableMap<String, String> = mutableMapOf()
+        form {
+            div("row g-3 ml-3 mr-3 pb-2 pt-2  border-bottom") {
+                projectInformation.putAll(
+                    projectInformation.keys.zip(
+                        listOf(
+                            project.name,
+                            project.description ?: "",
+                            project.url ?: "",
+                        )
+                    )
+                )
+                projectInformation
+                    .forEach { (header, text) ->
+                        div("col-md-6 pl-0 pr-0") {
+                            label(classes = "control-label col-auto justify-content-between pl-0") {
+                                +header
+                            }
+                        }
+                        div("col-md-6 pl-0") {
+                            div("controls col-auto pl-0") {
+                                input(InputType.text, classes = "form-control-plaintext pt-0 pb-0") {
+                                    attrs.id = header
+                                    attrs.defaultValue = text
+                                    attrs.disabled = true
+                                    attrs {
+                                        onChangeFunction = {
+                                            val tg = it.target as HTMLInputElement
+                                            val newValue = tg.value
+                                            newProjectInformation[header] = newValue
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+            }
+        }
+
+        div("ml-3 mt-2 align-items-right float-right") {
+            button(classes = "btn") {
+                fontAwesomeIcon {
+                    attrs.icon = faCheck
+                }
+                attrs.id = "Save new project info"
+                attrs.hidden = true
+                attrs.onClickFunction = {
+                    newProjectInformation.forEach { (key, value) ->
+                        projectInformation[key] = value
+                        (document.getElementById(key) as HTMLInputElement).value = value
+                    }
+                    updateProjectBuilder(projectInformation)
+                    turnEditMode(isOff = true)
+                }
+            }
+
+            button(classes = "btn") {
+                fontAwesomeIcon {
+                    attrs.icon = faTimesCircle
+                }
+                attrs.id = "Cancel"
+                attrs.hidden = true
+                attrs.onClickFunction = {
+                    projectInformation.forEach { (key, value) ->
+                        (document.getElementById(key) as HTMLInputElement).value = value
+                    }
+                    newProjectInformation.clear()
+                    turnEditMode(isOff = true)
+                }
+            }
+        }
+
+        div("ml-3 mt-2 align-items-left justify-content-between") {
+            fontAwesomeIcon(icon = faHistory)
+
+            button(classes = "btn btn-link text-left") {
+                +"Latest Execution"
+                attrs.onClickFunction = {
+                    scope.launch {
+                        switchToLatestExecution()
+                    }
+                }
+            }
+        }
+        div("ml-3 align-items-left") {
+            fontAwesomeIcon(icon = faCalendarAlt)
+            a(
+                href = "#/${project.organization.name}/${project.name}/history",
+                classes = "btn btn-link text-left"
+            ) {
+                +"Execution History"
+            }
+        }
+        div("ml-3 d-sm-flex align-items-left justify-content-between mt-2") {
+            button(type = ButtonType.button, classes = "btn btn-sm btn-danger") {
+                attrs.onClickFunction = {
+                    deleteProject()
+                }
+                +"Delete project"
+            }
+        }
+    }
+    private val typeSelection = cardComponent {
+        div("text-left") {
+            testingTypeButton(
+                TestingType.CUSTOM_TESTS,
+                "Evaluate your tool with your own tests from git",
+                "mr-2"
+            )
+            testingTypeButton(
+                TestingType.STANDARD_BENCHMARKS,
+                "Evaluate your tool with standard test suites",
+                "mt-3 mr-2"
+            )
+            testingTypeButton(
+                TestingType.CONTEST_MODE,
+                "Participate in SAVE contests with your tool",
+                "mt-3 mr-2"
+            )
+        }
+    }
+    private val fileUploader = fileUploader(
+        onFileSelect = { element ->
+            setState {
+                val availableFile = availableFiles.first { it.name == element.value }
+                files.add(availableFile)
+                bytesReceived += availableFile.sizeBytes
+                suiteByteSize += availableFile.sizeBytes
+                availableFiles.remove(availableFile)
+            }
+        },
+        onFileRemove = {
+            setState {
+                files.remove(it)
+                bytesReceived -= it.sizeBytes
+                suiteByteSize -= it.sizeBytes
+                availableFiles.add(it)
+            }
+        },
+        onFileInput = { postFileUpload(it) },
+        onExecutableChange = { selectedFile, checked ->
+            setState {
+                files[files.indexOf(selectedFile)] = selectedFile.copy(isExecutable = checked)
+            }
+        }
+    )
+    private val sdkSelection = sdkSelection({
+        setState {
+            selectedSdk = it.value
+            selectedSdkVersion = selectedSdk.getSdkVersions().first()
+        }
+    }, {
+        setState { selectedSdkVersion = it.value }
+    })
     private lateinit var responseFromDeleteProject: Response
 
     init {
@@ -375,25 +569,7 @@ class ProjectView : AbstractView<ProjectExecutionRouteProps, ProjectViewState>(f
                     +"Testing types"
                 }
 
-                child(cardComponent {
-                    div("text-left") {
-                        testingTypeButton(
-                            TestingType.CUSTOM_TESTS,
-                            "Evaluate your tool with your own tests from git",
-                            "mr-2"
-                        )
-                        testingTypeButton(
-                            TestingType.STANDARD_BENCHMARKS,
-                            "Evaluate your tool with standard test suites",
-                            "mt-3 mr-2"
-                        )
-                        testingTypeButton(
-                            TestingType.CONTEST_MODE,
-                            "Participate in SAVE contests with your tool",
-                            "mt-3 mr-2"
-                        )
-                    }
-                })
+                child(typeSelection)
             }
             // ===================== MIDDLE COLUMN =====================================================================
             div("col-4") {
@@ -402,32 +578,7 @@ class ProjectView : AbstractView<ProjectExecutionRouteProps, ProjectViewState>(f
                 }
 
                 // ======== file selector =========
-                child(fileUploader(
-                    onFileSelect = { element ->
-                        setState {
-                            val availableFile = availableFiles.first { it.name == element.value }
-                            files.add(availableFile)
-                            bytesReceived += availableFile.sizeBytes
-                            suiteByteSize += availableFile.sizeBytes
-                            availableFiles.remove(availableFile)
-                        }
-                    },
-                    onFileRemove = {
-                        setState {
-                            files.remove(it)
-                            bytesReceived -= it.sizeBytes
-                            suiteByteSize -= it.sizeBytes
-                            availableFiles.add(it)
-                        }
-                    },
-                    onFileInput = { postFileUpload(it) },
-                    onExecutableChange = { selectedFile, checked ->
-                        setState {
-                            files[files.indexOf(selectedFile)] = selectedFile.copy(isExecutable = checked)
-                        }
-                    }
-                )
-                ) {
+                child(fileUploader) {
                     attrs.isSubmitButtonPressed = state.isSubmitButtonPressed
                     attrs.files = state.files
                     attrs.availableFiles = state.availableFiles
@@ -438,56 +589,13 @@ class ProjectView : AbstractView<ProjectExecutionRouteProps, ProjectViewState>(f
                 }
 
                 // ======== sdk selection =========
-                child(sdkSelection({
-                    setState {
-                        selectedSdk = it.value
-                        selectedSdkVersion = selectedSdk.getSdkVersions().first()
-                    }
-                }, {
-                    setState { selectedSdkVersion = it.value }
-                })) {
+                child(sdkSelection) {
                     attrs.selectedSdk = state.selectedSdk
                     attrs.selectedSdkVersion = state.selectedSdkVersion
                 }
 
                 // ======== test resources selection =========
-                child(testResourcesSelection(
-                    updateGitUrlFromInputField = {
-                        setState {
-                            gitUrlFromInputField = (it.target as HTMLInputElement).value
-                        }
-                    },
-                    updateGitBranchOrCommitInputField = {
-                        setState {
-                            gitBranchOrCommitFromInputField = (it.target as HTMLInputElement).value
-                        }
-                    },
-                    updateTestRootPath = {
-                        setState {
-                            testRootPath = (it.target as HTMLInputElement).value
-                        }
-                    },
-                    setTestRootPathFromHistory = {
-                        setState {
-                            testRootPath = it
-                        }
-                    },
-                    setExecCmd = {
-                        setState {
-                            execCmd = (it.target as HTMLInputElement).value
-                        }
-                    },
-                    setBatchSize = {
-                        setState {
-                            batchSizeForAnalyzer = (it.target as HTMLInputElement).value
-                        }
-                    },
-                    setSelectedLanguageForStandardTests = {
-                        setState {
-                            selectedLanguageForStandardTests = it
-                        }
-                    }
-                )) {
+                child(testResourcesSelection) {
                     attrs.testingType = state.testingType
                     attrs.isSubmitButtonPressed = state.isSubmitButtonPressed
                     attrs.gitDto = gitDto
@@ -523,109 +631,7 @@ class ProjectView : AbstractView<ProjectExecutionRouteProps, ProjectViewState>(f
                     }
                 }
 
-                child(cardComponent(true, true) {
-                    val newProjectInformation: MutableMap<String, String> = mutableMapOf()
-                    form {
-                        div("row g-3 ml-3 mr-3 pb-2 pt-2  border-bottom") {
-                            projectInformation.putAll(
-                                projectInformation.keys.zip(
-                                    listOf(
-                                        project.name,
-                                        project.description ?: "",
-                                        project.url ?: "",
-                                    )
-                                )
-                            )
-                            projectInformation
-                                .forEach { (header, text) ->
-                                    div("col-md-6 pl-0 pr-0") {
-                                        label(classes = "control-label col-auto justify-content-between pl-0") {
-                                            +header
-                                        }
-                                    }
-                                    div("col-md-6 pl-0") {
-                                        div("controls col-auto pl-0") {
-                                            input(InputType.text, classes = "form-control-plaintext pt-0 pb-0") {
-                                                attrs.id = header
-                                                attrs.defaultValue = text
-                                                attrs.disabled = true
-                                                attrs {
-                                                    onChangeFunction = {
-                                                        val tg = it.target as HTMLInputElement
-                                                        val newValue = tg.value
-                                                        newProjectInformation[header] = newValue
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                        }
-                    }
-
-                    div("ml-3 mt-2 align-items-right float-right") {
-                        button(classes = "btn") {
-                            fontAwesomeIcon {
-                                attrs.icon = faCheck
-                            }
-                            attrs.id = "Save new project info"
-                            attrs.hidden = true
-                            attrs.onClickFunction = {
-                                newProjectInformation.forEach { (key, value) ->
-                                    projectInformation[key] = value
-                                    (document.getElementById(key) as HTMLInputElement).value = value
-                                }
-                                updateProjectBuilder(projectInformation)
-                                turnEditMode(isOff = true)
-                            }
-                        }
-
-                        button(classes = "btn") {
-                            fontAwesomeIcon {
-                                attrs.icon = faTimesCircle
-                            }
-                            attrs.id = "Cancel"
-                            attrs.hidden = true
-                            attrs.onClickFunction = {
-                                projectInformation.forEach { (key, value) ->
-                                    (document.getElementById(key) as HTMLInputElement).value = value
-                                }
-                                newProjectInformation.clear()
-                                turnEditMode(isOff = true)
-                            }
-                        }
-                    }
-
-                    div("ml-3 mt-2 align-items-left justify-content-between") {
-                        fontAwesomeIcon(icon = faHistory)
-
-                        button(classes = "btn btn-link text-left") {
-                            +"Latest Execution"
-                            attrs.onClickFunction = {
-                                scope.launch {
-                                    switchToLatestExecution()
-                                }
-                            }
-                        }
-                    }
-                    div("ml-3 align-items-left") {
-                        fontAwesomeIcon(icon = faCalendarAlt)
-                        a(
-                            href = "#/${project.organization.name}/${project.name}/history",
-                            classes = "btn btn-link text-left"
-                        ) {
-                            +"Execution History"
-                        }
-                    }
-                    div("ml-3 d-sm-flex align-items-left justify-content-between mt-2") {
-                        button(type = ButtonType.button, classes = "btn btn-sm btn-danger") {
-                            attrs.onClickFunction = {
-                                deleteProject()
-                            }
-                            +"Delete project"
-                        }
-                    }
-                })
+                child(projectInfoCard)
             }
         }
     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -208,7 +208,6 @@ class ProjectView : AbstractView<ProjectExecutionRouteProps, ProjectViewState>(f
     )
     private val testResourcesSelection = testResourcesSelection(
         updateGitUrlFromInputField = {
-            console.log("updateGitUrlFromInputField with ${it.target}")
             it.preventDefault()
             setState {
                 gitUrlFromInputField = (it.target as HTMLInputElement).value


### PR DESCRIPTION
All functional components shouldn't be called directly from `Component.render` method. Instead, they should be stored in class properties. Explanation of this behavior can be found [here](https://dev.to/igor_bykov/react-calling-functional-components-as-functions-1d3l)
* The following functional components are covered: `executionStatistics`, `testResourcesSelection`, `cardComponent`, `topBar`, `scrollToTopButton`, `executionTestsNotFound`, `testExecutionFiltersRow`, `fileUploader`, `testExecutionDetailsView`, `withRouter`
* function components inside other function components are OK, we need to make sure that top-level function components aren't recreated; `testStatusComponent` shouldn't be extracted, because it's called for a new table row each time
* Make Boolean properties in external interfaces nullable
* Changed `executionTestsNotFound` to receive tests count via props instead of function parameter
* Replace String with dynamic for fa icons in HistoryView.kt

Closes #426