### PR TITLE
Mark remaining test executions as failed if agent returned only part of results

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -2,28 +2,6 @@
 
 package org.cqfn.save.agent
 
-import generated.SAVE_CLOUD_VERSION
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
-import kotlinx.serialization.modules.subclass
-import okio.FileSystem
-import okio.Path.Companion.toPath
 import org.cqfn.save.agent.utils.logDebugCustom
 import org.cqfn.save.agent.utils.logErrorCustom
 import org.cqfn.save.agent.utils.logInfoCustom
@@ -39,8 +17,31 @@ import org.cqfn.save.reporter.Report
 import org.cqfn.save.utils.adjustLocation
 import org.cqfn.save.utils.toTestResultDebugInfo
 import org.cqfn.save.utils.toTestResultStatus
+
+import generated.SAVE_CLOUD_VERSION
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
 import kotlin.native.concurrent.AtomicLong
 import kotlin.native.concurrent.AtomicReference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
 
 /**
  * A main class for SAVE Agent

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -2,6 +2,28 @@
 
 package org.cqfn.save.agent
 
+import generated.SAVE_CLOUD_VERSION
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import okio.FileSystem
+import okio.Path.Companion.toPath
 import org.cqfn.save.agent.utils.logDebugCustom
 import org.cqfn.save.agent.utils.logErrorCustom
 import org.cqfn.save.agent.utils.logInfoCustom
@@ -17,32 +39,8 @@ import org.cqfn.save.reporter.Report
 import org.cqfn.save.utils.adjustLocation
 import org.cqfn.save.utils.toTestResultDebugInfo
 import org.cqfn.save.utils.toTestResultStatus
-
-import generated.SAVE_CLOUD_VERSION
-import io.ktor.client.HttpClient
-import io.ktor.client.request.accept
-import io.ktor.client.request.post
-import io.ktor.client.request.url
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import okio.FileSystem
-import okio.Path.Companion.toPath
-
 import kotlin.native.concurrent.AtomicLong
 import kotlin.native.concurrent.AtomicReference
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.datetime.Clock
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
-import kotlinx.serialization.modules.subclass
 
 /**
  * A main class for SAVE Agent
@@ -260,7 +258,7 @@ class SaveAgent(internal val config: AgentConfiguration,
         return httpClient.post("${config.orchestratorUrl}/heartbeat") {
             contentType(ContentType.Application.Json)
             accept(ContentType.Application.Json)
-            body = Heartbeat(config.id, state.value, executionProgress)
+            body = Heartbeat(config.id, state.value, executionProgress, Clock.System.now().toLocalDateTime(TimeZone.UTC))
         }
     }
 

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
@@ -142,13 +142,16 @@ class TestExecutionController(private val testExecutionService: TestExecutionSer
         @RequestParam("status") status: String,
         @RequestBody agentIds: Collection<String>
     ) {
-        if (status == AgentState.CRASHED.name) {
-            testExecutionService.markTestExecutionsOfCrashedAgentsAsFailed(agentIds)
-        } else {
-            throw ResponseStatusException(
+        when(status) {
+            AgentState.CRASHED.name -> testExecutionService.markTestExecutionsOfAgentsAsFailed(agentIds)
+            AgentState.FINISHED.name -> testExecutionService.markTestExecutionsOfAgentsAsFailed(agentIds) {
+                it.status == TestResultStatus.READY_FOR_TESTING
+            }
+            else -> throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
-                "For now only CRASHED status supported"
+                "For now only CRASHED and FINISHED statuses are supported"
             )
+        }
         }
     }
 

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/TestExecutionController.kt
@@ -142,7 +142,7 @@ class TestExecutionController(private val testExecutionService: TestExecutionSer
         @RequestParam("status") status: String,
         @RequestBody agentIds: Collection<String>
     ) {
-        when(status) {
+        when (status) {
             AgentState.CRASHED.name -> testExecutionService.markTestExecutionsOfAgentsAsFailed(agentIds)
             AgentState.FINISHED.name -> testExecutionService.markTestExecutionsOfAgentsAsFailed(agentIds) {
                 it.status == TestResultStatus.READY_FOR_TESTING
@@ -151,7 +151,6 @@ class TestExecutionController(private val testExecutionService: TestExecutionSer
                 HttpStatus.BAD_REQUEST,
                 "For now only CRASHED and FINISHED statuses are supported"
             )
-        }
         }
     }
 

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestExecutionService.kt
@@ -252,12 +252,13 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
     }
 
     /**
-     * @param crashedAgents the list of agents, which weren't sent heartbeats for a some time and are considered as crashed
+     * @param agentsList the list of agents, for which corresponding test executions should be marked as failed
+     * @param condition
      */
     @Transactional
     @Suppress("UnsafeCallOnNullableType")
-    fun markTestExecutionsOfCrashedAgentsAsFailed(crashedAgents: Collection<String>) {
-        crashedAgents.forEach { agentContainerId ->
+    fun markTestExecutionsOfAgentsAsFailed(agentsList: Collection<String>, condition: (TestExecution) -> Boolean = { true }) {
+        agentsList.forEach { agentContainerId ->
             val agent = requireNotNull(agentRepository.findByContainerId(agentContainerId)) {
                 "Agent with containerId=[$agentContainerId] was not found in the DB"
             }
@@ -267,7 +268,8 @@ class TestExecutionService(private val testExecutionRepository: TestExecutionRep
             val testExecutionList = testExecutionRepository.findByExecutionIdAndAgentId(
                 executionId,
                 agentId
-            )
+            ).filter(condition)
+
             if (testExecutionList.isEmpty()) {
                 // Crashed agent could be not assigned with tests, so just warn and return
                 log.warn("Can't find `test_execution`s for executionId=$executionId and agentId=$agentId")

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
@@ -102,7 +102,7 @@ class CloningRepositoryControllerTest {
 
     @BeforeEach
     fun webClientSetUp() {
-        webTestClient.mutate().responseTimeout(Duration.ofSeconds(2)).build()
+        webTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(2)).build()
 
         whenever(projectService.findByNameAndOrganizationName("huaweiName", "Huawei"))
             .thenReturn(testProject)

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/Heartbeat.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/Heartbeat.kt
@@ -4,11 +4,11 @@
 
 package org.cqfn.save.agent
 
-import kotlinx.serialization.Contextual
 import org.cqfn.save.test.TestDto
-
-import kotlinx.serialization.Serializable
 import org.cqfn.save.utils.LocalDateTime
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
 
 /**
  * Progress of tests execution

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/Heartbeat.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/Heartbeat.kt
@@ -4,9 +4,11 @@
 
 package org.cqfn.save.agent
 
+import kotlinx.serialization.Contextual
 import org.cqfn.save.test.TestDto
 
 import kotlinx.serialization.Serializable
+import org.cqfn.save.utils.LocalDateTime
 
 /**
  * Progress of tests execution
@@ -27,11 +29,16 @@ data class ExecutionProgress(val percentCompletion: Int) {
  * @property agentId unique ID of the agent which sent the heartbeat
  * @property state current state of the Agent
  * @property executionProgress current progress of tests execution with this Agent
+ * @property currentTime current time
  */
 @Serializable
-data class Heartbeat(val agentId: String,
-                     val state: AgentState,
-                     val executionProgress: ExecutionProgress)
+data class Heartbeat(
+    val agentId: String,
+    val state: AgentState,
+    val executionProgress: ExecutionProgress,
+    @Contextual
+    val currentTime: LocalDateTime,
+)
 
 /**
  * A response from Orchestrator to Agent

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/Heartbeat.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/Heartbeat.kt
@@ -29,7 +29,7 @@ data class ExecutionProgress(val percentCompletion: Int) {
  * @property agentId unique ID of the agent which sent the heartbeat
  * @property state current state of the Agent
  * @property executionProgress current progress of tests execution with this Agent
- * @property currentTime current time
+ * @property timestamp the time of heartbeat posting
  */
 @Serializable
 data class Heartbeat(
@@ -37,7 +37,7 @@ data class Heartbeat(
     val state: AgentState,
     val executionProgress: ExecutionProgress,
     @Contextual
-    val currentTime: LocalDateTime,
+    val timestamp: LocalDateTime,
 )
 
 /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/LocalDateTimeConfig.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/LocalDateTimeConfig.kt
@@ -52,15 +52,4 @@ class LocalDateTimeConfig {
                     configurer.defaultCodecs().kotlinSerializationJsonDecoder(decoder)
                 }
             }
-
-    @Bean
-    fun kotlinSerializationWebClientCustomizer(
-        kotlinSerializationJsonEncoder: KotlinSerializationJsonEncoder,
-        kotlinSerializationJsonDecoder: KotlinSerializationJsonDecoder,
-    ) = WebClientCustomizer { builder ->
-        builder.codecs {
-            it.defaultCodecs().kotlinSerializationJsonEncoder(kotlinSerializationJsonEncoder)
-            it.defaultCodecs().kotlinSerializationJsonDecoder(kotlinSerializationJsonDecoder)
-        }
-    }
 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/LocalDateTimeConfig.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/LocalDateTimeConfig.kt
@@ -22,6 +22,7 @@ import java.time.LocalDateTime
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 
 internal val json = Json {
     serializersModule = SerializersModule {
@@ -51,4 +52,15 @@ class LocalDateTimeConfig {
                     configurer.defaultCodecs().kotlinSerializationJsonDecoder(decoder)
                 }
             }
+
+    @Bean
+    fun kotlinSerializationWebClientCustomizer(
+        kotlinSerializationJsonEncoder: KotlinSerializationJsonEncoder,
+        kotlinSerializationJsonDecoder: KotlinSerializationJsonDecoder,
+    ) = WebClientCustomizer { builder ->
+        builder.codecs {
+            it.defaultCodecs().kotlinSerializationJsonEncoder(kotlinSerializationJsonEncoder)
+            it.defaultCodecs().kotlinSerializationJsonDecoder(kotlinSerializationJsonDecoder)
+        }
+    }
 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/LocalDateTimeConfig.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/config/LocalDateTimeConfig.kt
@@ -22,7 +22,6 @@ import java.time.LocalDateTime
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
-import org.springframework.boot.web.reactive.function.client.WebClientCustomizer
 
 internal val json = Json {
     serializersModule = SerializersModule {

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -85,6 +85,7 @@ class HeartbeatController(private val agentService: AgentService,
                         if (isSavingSuccessful) {
                             handleVacantAgent(heartbeat.agentId)
                         } else {
+                            println("\n\n222222222222222222")
                             // Agent finished its work, however only part of results were received, other should be marked as failed
                             agentService.markTestExecutionsAsFailed(listOf(heartbeat.agentId), AgentState.FINISHED)
                                 .subscribeOn(agentService.scheduler)
@@ -129,6 +130,7 @@ class HeartbeatController(private val agentService: AgentService,
             currentAgentId !in crashedAgentsList
         }.forEach { (currentAgentId, stateToLatestHeartBeatPair) ->
             val duration = Duration.between(stateToLatestHeartBeatPair.second, LocalDateTime.now()).toMillis()
+            //println("\n\nDURATION for ${currentAgentId}: ${duration} ${LocalDateTime.now()} - ${stateToLatestHeartBeatPair.second}")
             if (duration >= configProperties.agentsHeartBeatTimeoutMillis) {
                 logger.debug("Adding $currentAgentId to list crashed agents")
                 crashedAgentsList.add(currentAgentId)

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -66,7 +66,7 @@ class HeartbeatController(private val agentService: AgentService,
     @PostMapping("/heartbeat")
     @OptIn(ExperimentalSerializationApi::class)
     fun acceptHeartbeat(@RequestBody heartbeat: Heartbeat): Mono<String> {
-        logger.info("Got heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId}")
+        logger.info("\n\n\nGot heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId} ${heartbeat.currentTime}")
         updateAgentHeartbeatTimeStamps(heartbeat.agentId, heartbeat.state)
 
         // store new state into DB

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -66,7 +66,7 @@ class HeartbeatController(private val agentService: AgentService,
     @PostMapping("/heartbeat")
     @OptIn(ExperimentalSerializationApi::class)
     fun acceptHeartbeat(@RequestBody heartbeat: Heartbeat): Mono<String> {
-        logger.info("\n\n\nGot heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId} ${heartbeat.timestamp}")
+        logger.info("Got heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId} ${heartbeat.timestamp}")
         updateAgentHeartbeatTimeStamps(heartbeat)
 
         // store new state into DB
@@ -127,6 +127,7 @@ class HeartbeatController(private val agentService: AgentService,
             currentAgentId !in crashedAgentsList
         }.forEach { (currentAgentId, stateToLatestHeartBeatPair) ->
             val duration = Duration.between(stateToLatestHeartBeatPair.second, LocalDateTime.now()).toMillis()
+            println("\n\nDURATION for ${currentAgentId}: ${duration} ${LocalDateTime.now()} - ${stateToLatestHeartBeatPair.second}")
             if (duration >= configProperties.agentsHeartBeatTimeoutMillis) {
                 logger.debug("Adding $currentAgentId to list crashed agents")
                 crashedAgentsList.add(currentAgentId)

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -115,8 +115,7 @@ class HeartbeatController(private val agentService: AgentService,
     /**
      * Collect information about the latest heartbeats from agents, in aim to determine crashed one later
      *
-     * @param agentId
-     * @param state
+     * @param heartbeat
      */
     fun updateAgentHeartbeatTimeStamps(heartbeat: Heartbeat) {
         agentsLatestHeartBeatsMap[heartbeat.agentId] = heartbeat.state.name to heartbeat.timestamp

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -85,7 +85,6 @@ class HeartbeatController(private val agentService: AgentService,
                         if (isSavingSuccessful) {
                             handleVacantAgent(heartbeat.agentId)
                         } else {
-                            println("\n\n222222222222222222")
                             // Agent finished its work, however only part of results were received, other should be marked as failed
                             agentService.markTestExecutionsAsFailed(listOf(heartbeat.agentId), AgentState.FINISHED)
                                 .subscribeOn(agentService.scheduler)
@@ -130,7 +129,7 @@ class HeartbeatController(private val agentService: AgentService,
             currentAgentId !in crashedAgentsList
         }.forEach { (currentAgentId, stateToLatestHeartBeatPair) ->
             val duration = Duration.between(stateToLatestHeartBeatPair.second, LocalDateTime.now()).toMillis()
-            //println("\n\nDURATION for ${currentAgentId}: ${duration} ${LocalDateTime.now()} - ${stateToLatestHeartBeatPair.second}")
+            // println("\n\nDURATION for ${currentAgentId}: ${duration} ${LocalDateTime.now()} - ${stateToLatestHeartBeatPair.second}")
             if (duration >= configProperties.agentsHeartBeatTimeoutMillis) {
                 logger.debug("Adding $currentAgentId to list crashed agents")
                 crashedAgentsList.add(currentAgentId)

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -66,8 +66,8 @@ class HeartbeatController(private val agentService: AgentService,
     @PostMapping("/heartbeat")
     @OptIn(ExperimentalSerializationApi::class)
     fun acceptHeartbeat(@RequestBody heartbeat: Heartbeat): Mono<String> {
-        logger.info("\n\n\nGot heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId} ${heartbeat.currentTime}")
-        updateAgentHeartbeatTimeStamps(heartbeat.agentId, heartbeat.state)
+        logger.info("\n\n\nGot heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId} ${heartbeat.timestamp}")
+        updateAgentHeartbeatTimeStamps(heartbeat)
 
         // store new state into DB
         return agentService.updateAgentStatusesWithDto(
@@ -110,13 +110,13 @@ class HeartbeatController(private val agentService: AgentService,
         }
 
     /**
-     * Collect information about latest heartbeats from agents, in aim to determine crashed one later
+     * Collect information about the latest heartbeats from agents, in aim to determine crashed one later
      *
      * @param agentId
      * @param state
      */
-    fun updateAgentHeartbeatTimeStamps(agentId: String, state: AgentState) {
-        agentsLatestHeartBeatsMap[agentId] = state.name to LocalDateTime.now()
+    fun updateAgentHeartbeatTimeStamps(heartbeat: Heartbeat) {
+        agentsLatestHeartBeatsMap[heartbeat.agentId] = heartbeat.state.name to heartbeat.timestamp
     }
 
     /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -120,7 +120,11 @@ class AgentService {
         .uri("/testExecutions/agent/$agentId/${TestResultStatus.READY_FOR_TESTING}")
         .retrieve()
         .bodyToMono<List<TestExecutionDto>>()
-        .map { it.isEmpty() }
+        .map {
+            println("=================${it} ${it.isEmpty()}")
+            it.isEmpty()
+        }
+        .also { println("finished") }
 
     /**
      * If an error occurs, should try to resend tests

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -121,7 +121,7 @@ class AgentService {
         .retrieve()
         .bodyToMono<List<TestExecutionDto>>()
         .map {
-            println("=================${it} ${it.isEmpty()}")
+            println("=================$it ${it.isEmpty()}")
             it.isEmpty()
         }
         .also { println("finished") }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -265,6 +265,7 @@ class AgentService {
      *
      * @param agentsList the list of agents, for which, according the [status] corresponding test executions should be marked as failed
      * @param status
+     * @return a bodiless response entity
      */
     fun markTestExecutionsAsFailed(agentsList: Collection<String>, status: AgentState): Mono<BodilessResponseEntity> {
         log.debug("Attempt to mark test executions of agents=$agentsList as failed with internal error")

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -162,7 +162,7 @@ class AgentService {
                 log.info("Agents $crashedAgentIds has been crashed with internal error")
             }
             .then(
-                markTestExecutionsOfCrashedAgentsAsFailed(crashedAgentIds)
+                markTestExecutionsAsFailed(crashedAgentIds, AgentState.CRASHED)
             )
             .subscribeOn(scheduler)
             .subscribe()
@@ -260,11 +260,17 @@ class AgentService {
             .toBodilessEntity()
     }
 
-    private fun markTestExecutionsOfCrashedAgentsAsFailed(crashedAgentIds: Collection<String>): Mono<BodilessResponseEntity> {
-        log.debug("Attempt to mark test executions of crashed agents=$crashedAgentIds as failed with internal error")
+    /**
+     * Mark agent's test executions as failed
+     *
+     * @param agentsList the list of agents, for which, according the [status] corresponding test executions should be marked as failed
+     * @param status
+     */
+    fun markTestExecutionsAsFailed(agentsList: Collection<String>, status: AgentState): Mono<BodilessResponseEntity> {
+        log.debug("Attempt to mark test executions of agents=$agentsList as failed with internal error")
         return webClientBackend.post()
-            .uri("/testExecution/setStatusByAgentIds?status=${AgentState.CRASHED.name}")
-            .bodyValue(crashedAgentIds)
+            .uri("/testExecution/setStatusByAgentIds?status=${status.name}")
+            .bodyValue(agentsList)
             .retrieve()
             .toBodilessEntity()
     }

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -298,7 +298,7 @@ class HeartbeatControllerTest {
             },
             mockAgentStatuses = false,
         ) {
-            assertTrue(crashedAgentsList.toList() == listOf("test-1", "test-2"))
+            assertTrue(crashedAgentsList.toList().sorted() == listOf("test-1", "test-2"))
         }
     }
 

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -239,7 +239,7 @@ class HeartbeatControllerTest {
                 Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0)),
                 Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0)),
             ),
-            heartBeatInterval = 1_000,
+            heartBeatInterval = 1_500,
             testBatch = TestBatch(
                 listOf(
                     TestDto("/path/to/test-1", "WarnPlugin", 1, "hash1", listOf("tag")),

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -248,15 +248,15 @@ class HeartbeatControllerTest {
                 AgentStatusDto(LocalDateTime.now(), AgentState.BUSY, "test-2"),
             ),
             heartbeats = listOf(
-                Heartbeat("test-1", AgentState.STARTING, ExecutionProgress(0), stubTime),
-                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), stubTime),
-                Heartbeat("test-2", AgentState.BUSY, ExecutionProgress(0), stubTime),
-                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), stubTime),
-                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), stubTime),
-                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), stubTime),
-                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), stubTime),
+                Heartbeat("test-1", AgentState.STARTING, ExecutionProgress(0), LocalDateTime.now()),
+                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), LocalDateTime.now().plusSeconds(1)),
+                Heartbeat("test-2", AgentState.BUSY, ExecutionProgress(0), LocalDateTime.now().plusSeconds(2)),
+                // 3 absent heartbeats from test-2
+                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), LocalDateTime.now().plusSeconds(3)),
+                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), LocalDateTime.now().plusSeconds(4)),
+                Heartbeat("test-1", AgentState.BUSY, ExecutionProgress(0), LocalDateTime.now().plusSeconds(6)),
             ),
-            heartBeatInterval = 1_500,
+            heartBeatInterval = 1_000,
             testBatch = TestBatch(
                 listOf(
                     TestDto("/path/to/test-1", "WarnPlugin", 1, "hash1", listOf("tag")),

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -8,6 +8,7 @@ import org.cqfn.save.entities.AgentStatusDto
 import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.entities.TestSuite
 import org.cqfn.save.orchestrator.config.Beans
+import org.cqfn.save.orchestrator.config.LocalDateTimeConfig
 import org.cqfn.save.orchestrator.controller.HeartBeatInspector
 import org.cqfn.save.orchestrator.controller.crashedAgentsList
 import org.cqfn.save.orchestrator.service.AgentService
@@ -21,7 +22,6 @@ import org.cqfn.save.testutils.enqueue
 import org.cqfn.save.testutils.setDefaultResponseForPath
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import kotlinx.serialization.Contextual
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -41,6 +41,8 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.http.codec.json.KotlinSerializationJsonDecoder
+import org.springframework.http.codec.json.KotlinSerializationJsonEncoder
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -56,12 +58,14 @@ import java.util.concurrent.TimeUnit
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.cqfn.save.orchestrator.config.LocalDateTimeConfig
-import org.springframework.http.codec.json.KotlinSerializationJsonEncoder
-import org.springframework.http.codec.json.KotlinSerializationJsonDecoder
 
 @WebFluxTest
-@Import(Beans::class, AgentService::class, HeartBeatInspector::class, LocalDateTimeConfig::class)
+@Import(
+    Beans::class,
+    AgentService::class,
+    HeartBeatInspector::class,
+    LocalDateTimeConfig::class
+)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @EnableScheduling
@@ -76,13 +80,13 @@ class HeartbeatControllerTest {
     @BeforeEach
     fun webClientSetUp() {
         webClient = webClient
-        .mutate()
-        .codecs {
-            it.defaultCodecs().kotlinSerializationJsonEncoder(kotlinSerializationJsonEncoder)
-            it.defaultCodecs().kotlinSerializationJsonDecoder(kotlinSerializationJsonDecoder)
-        }
-        .responseTimeout(Duration.ofSeconds(2))
-        .build()
+            .mutate()
+            .codecs {
+                it.defaultCodecs().kotlinSerializationJsonEncoder(kotlinSerializationJsonEncoder)
+                it.defaultCodecs().kotlinSerializationJsonDecoder(kotlinSerializationJsonDecoder)
+            }
+            .responseTimeout(Duration.ofSeconds(2))
+            .build()
     }
 
     @AfterEach

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/controllers/CheckGitConnectivityTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/controllers/CheckGitConnectivityTest.kt
@@ -32,13 +32,13 @@ import java.time.Duration
 @AutoConfigureWebTestClient(timeout = "60000")
 @Suppress("TOO_LONG_FUNCTION", "LongMethod")
 class CheckGitConnectivityTest(
-    @Autowired private val webClient: WebTestClient,
+    @Autowired private var webClient: WebTestClient,
 ) : RepositoryVolume {
     @MockBean private lateinit var testDiscoveringService: TestDiscoveringService
 
     @BeforeEach
     fun webClientSetUp() {
-        webClient.mutate().responseTimeout(Duration.ofSeconds(5)).build()
+        webClient = webClient.mutate().responseTimeout(Duration.ofSeconds(5)).build()
         whenever(testDiscoveringService.getRootTestConfig(any())).thenReturn(mock())
     }
 

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectTest.kt
@@ -60,7 +60,7 @@ import kotlin.io.path.isExecutable
 @AutoConfigureWebTestClient(timeout = "60000")
 @Suppress("TOO_LONG_FUNCTION", "LongMethod")
 class DownloadProjectTest(
-    @Autowired private val webClient: WebTestClient,
+    @Autowired private var webClient: WebTestClient,
     @Autowired private val configProperties: ConfigProperties,
     @Autowired private val objectMapper: ObjectMapper
 ) : RepositoryVolume {
@@ -71,7 +71,7 @@ class DownloadProjectTest(
 
     @BeforeEach
     fun webClientSetUp() {
-        webClient.mutate().responseTimeout(Duration.ofSeconds(2)).build()
+        webClient = webClient.mutate().responseTimeout(Duration.ofSeconds(2)).build()
         whenever(testDiscoveringService.getRootTestConfig(any())).thenReturn(mock())
         whenever(testDiscoveringService.getAllTests(any(), any())).thenReturn(
             sequenceOf(TestDto("foo", "fooPlugin", 15, "86", emptyList()))


### PR DESCRIPTION
### What's done:
* If AGENT returned only part of results -> MARK ALL other tests as FAILED (with internal error); (continuation of [#208](https://github.com/analysis-dev/save-cloud/issues/208))
* Agent: store timestamps in heartbeats
* Add test