### PR TITLE
Measure duration of docker commands called from orchestrator

### DIFF
--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -92,7 +92,3 @@ kotlin.sourceSets.getByName("main") {
 tasks.withType<KotlinCompile>().forEach {
     it.dependsOn(generateVersionFileTaskProvider)
 }
-
-tasks.withType<Test> {
-    testLogging.showStandardStreams = true
-}

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
@@ -11,7 +11,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.util.function.Supplier
 
-internal const val dockerMetricPrefix = "save.orchestrator.docker"
+internal const val DOCKER_METRIC_PREFIX = "save.orchestrator.docker"
 
 /**
  * Execute this async docker command while recording its execution duration.

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
@@ -47,11 +47,11 @@ inline fun <reified CMD_T : SyncDockerCmd<RES_T>, RES_T> CMD_T.execTimed(
     meterRegistry: MeterRegistry,
     name: String,
     vararg tags: String,
-): RES_T {
+): RES_T? {
     val timer = meterRegistry.timer(name, "cmd", "${CMD_T::class.simpleName}", *tags)
     return timer.record(Supplier {
         exec()
-    })!!
+    })
 }
 
 /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
@@ -4,6 +4,56 @@
 
 package org.cqfn.save.orchestrator
 
+import com.github.dockerjava.api.async.ResultCallback
+import com.github.dockerjava.api.command.AsyncDockerCmd
+import com.github.dockerjava.api.command.SyncDockerCmd
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.util.function.Supplier
+
+internal val dockerMetricPrefix = "save.orchestrator.docker"
+
+/**
+ * Execute this async docker command while recording its execution duration.
+ *
+ * @param meterRegistry a registry to record data to
+ * @param name name of the timer
+ * @param tags additional tags for the timer (command name in form of Java class name is assigned automatically)
+ * @param resultCallbackProducer a function returning result callback. Should call its argument to record duration.
+ * @return async result
+ */
+inline fun <reified CMD_T : AsyncDockerCmd<CMD_T, A_RES_T>, RC_T : ResultCallback<A_RES_T>, A_RES_T> CMD_T.execTimed(
+    meterRegistry: MeterRegistry,
+    name: String,
+    vararg tags: String,
+    resultCallbackProducer: (() -> Unit) -> RC_T,
+): RC_T {
+    val timer = meterRegistry.timer(name, "cmd", "${CMD_T::class.simpleName}", *tags)
+    val sample = Timer.start(meterRegistry)
+    return exec(resultCallbackProducer {
+        sample.stop(timer)
+    })
+}
+
+/**
+ * Execute this sync docker command while recording its execution duration.
+ *
+ * @param meterRegistry a registry to record data to
+ * @param name name of the timer
+ * @param tags additional tags for the timer (command name in form of Java class name is assigned automatically)
+ * @return sync result
+ */
+inline fun <reified CMD_T : SyncDockerCmd<RES_T>, RES_T> CMD_T.execTimed(
+    meterRegistry: MeterRegistry,
+    name: String,
+    vararg tags: String,
+): RES_T {
+    val timer = meterRegistry.timer(name, "cmd", "${CMD_T::class.simpleName}", *tags)
+    return timer.record(Supplier {
+        exec()
+    })!!
+}
+
 /**
  * Create synthetic toml config for standard mode in aim to execute all suites at the same time
  *

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/Utils.kt
@@ -11,7 +11,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.util.function.Supplier
 
-internal val dockerMetricPrefix = "save.orchestrator.docker"
+internal const val dockerMetricPrefix = "save.orchestrator.docker"
 
 /**
  * Execute this async docker command while recording its execution duration.

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -70,7 +70,7 @@ class ContainerManager(private val settings: DockerSettings,
                                           runCmd: String,
                                           containerName: String,
     ): String {
-        val baseImage = dockerClient.listImagesCmd().execTimed(meterRegistry, "$dockerMetricPrefix.image.list").find {
+        val baseImage = dockerClient.listImagesCmd().execTimed(meterRegistry, "$dockerMetricPrefix.image.list")!!.find {
             // fixme: sometimes createImageCmd returns short id without prefix, sometimes full and with prefix.
             it.id.replaceFirst("sha256:", "").startsWith(baseImageId.replaceFirst("sha256:", ""))
         }
@@ -101,7 +101,7 @@ class ContainerManager(private val settings: DockerSettings,
             )
             .execTimed(meterRegistry, "$dockerMetricPrefix.container.create")
 
-        return createContainerCmdResponse.id
+        return createContainerCmdResponse!!.id
     }
 
     /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -3,13 +3,12 @@ package org.cqfn.save.orchestrator.docker
 import org.cqfn.save.domain.Sdk
 import org.cqfn.save.orchestrator.config.DockerSettings
 import org.cqfn.save.orchestrator.copyRecursivelyWithAttributes
-import org.cqfn.save.orchestrator.dockerMetricPrefix
+import org.cqfn.save.orchestrator.DOCKER_METRIC_PREFIX
 import org.cqfn.save.orchestrator.execTimed
 import org.cqfn.save.orchestrator.getHostIp
 
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.command.BuildImageResultCallback
-import com.github.dockerjava.api.model.BuildResponseItem
 import com.github.dockerjava.api.model.HostConfig
 import com.github.dockerjava.api.model.LogConfig
 import com.github.dockerjava.core.DefaultDockerClientConfig
@@ -70,7 +69,7 @@ class ContainerManager(private val settings: DockerSettings,
                                           runCmd: String,
                                           containerName: String,
     ): String {
-        val baseImage = dockerClient.listImagesCmd().execTimed(meterRegistry, "$dockerMetricPrefix.image.list")!!.find {
+        val baseImage = dockerClient.listImagesCmd().execTimed(meterRegistry, "$DOCKER_METRIC_PREFIX.image.list")!!.find {
             // fixme: sometimes createImageCmd returns short id without prefix, sometimes full and with prefix.
             it.id.replaceFirst("sha256:", "").startsWith(baseImageId.replaceFirst("sha256:", ""))
         }
@@ -99,7 +98,7 @@ class ContainerManager(private val settings: DockerSettings,
                     }
                 )
             )
-            .execTimed(meterRegistry, "$dockerMetricPrefix.container.create")
+            .execTimed(meterRegistry, "$DOCKER_METRIC_PREFIX.container.create")
 
         return createContainerCmdResponse!!.id
     }
@@ -118,7 +117,7 @@ class ContainerManager(private val settings: DockerSettings,
             dockerClient.copyArchiveToContainerCmd(containerId)
                 .withTarInputStream(out.toByteArray().inputStream())
                 .withRemotePath(remotePath)
-                .execTimed(meterRegistry, "$dockerMetricPrefix.container.copy.archive")
+                .execTimed(meterRegistry, "$DOCKER_METRIC_PREFIX.container.copy.archive")
         }
     }
 

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -166,7 +166,7 @@ class ContainerManager(private val settings: DockerSettings,
                     super.onNext(item)
                     sample.stop(
                         meterRegistry.timer(
-                            "docker-build",
+                            "save.orchestrator.docker.build",
                             "baseImage", baseImage,
                         )
                     )

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -1,9 +1,9 @@
 package org.cqfn.save.orchestrator.docker
 
 import org.cqfn.save.domain.Sdk
+import org.cqfn.save.orchestrator.DOCKER_METRIC_PREFIX
 import org.cqfn.save.orchestrator.config.DockerSettings
 import org.cqfn.save.orchestrator.copyRecursivelyWithAttributes
-import org.cqfn.save.orchestrator.DOCKER_METRIC_PREFIX
 import org.cqfn.save.orchestrator.execTimed
 import org.cqfn.save.orchestrator.getHostIp
 
@@ -64,6 +64,7 @@ class ContainerManager(private val settings: DockerSettings,
      * @throws DockerException if docker daemon has returned an error
      * @throws RuntimeException if an exception not specific to docker has occurred
      */
+    @Suppress("UnsafeCallOnNullableType")
     internal fun createContainerFromImage(baseImageId: String,
                                           workingDir: String,
                                           runCmd: String,

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -53,6 +53,11 @@ class ContainerManager(private val settings: DockerSettings,
      */
     internal val dockerClient: DockerClient = DockerClientImpl.getInstance(dockerClientConfig, dockerHttpClient)
 
+    private fun buildCmdTimer(baseImage: String) = meterRegistry.timer(
+        "save.orchestrator.docker.build",
+        "baseImage", baseImage,
+    )
+
     /**
      * Creates a docker container
      *
@@ -164,12 +169,7 @@ class ContainerManager(private val settings: DockerSettings,
             buildCmd.exec(object : BuildImageResultCallback() {
                 override fun onNext(item: BuildResponseItem?) {
                     super.onNext(item)
-                    sample.stop(
-                        meterRegistry.timer(
-                            "save.orchestrator.docker.build",
-                            "baseImage", baseImage,
-                        )
-                    )
+                    sample.stop(buildCmdTimer(baseImage))
                 }
             })
         } finally {

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -164,8 +164,8 @@ class ContainerManager(private val settings: DockerSettings,
                 } ?: emptySet())
             buildCmd.execTimed(meterRegistry, "save.orchestrator.docker.build", "baseImage", baseImage) { record ->
                 object : BuildImageResultCallback() {
-                    override fun onNext(item: BuildResponseItem?) {
-                        super.onNext(item)
+                    override fun onComplete() {
+                        super.onComplete()
                         record()
                     }
                 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -16,6 +16,7 @@ import org.cqfn.save.utils.moveFileWithAttributes
 
 import com.github.dockerjava.api.exception.DockerException
 import generated.SAVE_CORE_VERSION
+import io.micrometer.core.instrument.MeterRegistry
 import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.exception.ZipException
 import org.apache.commons.io.FileUtils
@@ -44,11 +45,13 @@ import kotlin.io.path.createTempDirectory
  */
 @Service
 @OptIn(ExperimentalPathApi::class)
-class DockerService(private val configProperties: ConfigProperties) {
+class DockerService(private val configProperties: ConfigProperties,
+                    meterRegistry: MeterRegistry,
+) {
     /**
      * [ContainerManager] that is used to access docker daemon API
      */
-    internal val containerManager = ContainerManager(configProperties.docker)
+    internal val containerManager = ContainerManager(configProperties.docker, meterRegistry)
     private val executionDir = "/run/save-execution"
 
     @Suppress("NonBooleanPropertyPrefixedWithIs")

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/docker/ContainerManagerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/docker/ContainerManagerTest.kt
@@ -3,6 +3,7 @@ package org.cqfn.save.orchestrator.docker
 import org.cqfn.save.orchestrator.config.ConfigProperties
 
 import com.github.dockerjava.api.command.PullImageResultCallback
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -32,7 +33,7 @@ class ContainerManagerTest {
 
     @BeforeEach
     fun setUp() {
-        containerManager = ContainerManager(configProperties.docker)
+        containerManager = ContainerManager(configProperties.docker, CompositeMeterRegistry())
         containerManager.dockerClient.pullImageCmd("ubuntu")
             .withTag("latest")
             .exec(PullImageResultCallback())

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
@@ -5,12 +5,12 @@ import org.cqfn.save.entities.Project
 import org.cqfn.save.orchestrator.config.Beans
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.orchestrator.controller.AgentsController
+import org.cqfn.save.orchestrator.testutils.TestConfiguration
 import org.cqfn.save.testutils.createMockWebServer
 import org.cqfn.save.testutils.enqueue
 
 import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.model.Frame
-import io.micrometer.core.instrument.MeterRegistry
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -43,9 +43,8 @@ import kotlin.io.path.pathString
 @WebFluxTest(controllers = [AgentsController::class])  // to autowire everything for DockerService
 @MockBeans(
     MockBean(AgentService::class),
-    MockBean(MeterRegistry::class),
 )
-@Import(Beans::class, DockerService::class)
+@Import(Beans::class, DockerService::class, TestConfiguration::class)
 class DockerServiceTest {
     @Autowired private lateinit var dockerService: DockerService
     private lateinit var testImageId: String

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/service/DockerServiceTest.kt
@@ -10,6 +10,7 @@ import org.cqfn.save.testutils.enqueue
 
 import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.model.Frame
+import io.micrometer.core.instrument.MeterRegistry
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -41,7 +42,8 @@ import kotlin.io.path.pathString
 @DisabledOnOs(OS.WINDOWS, disabledReason = "Docker daemon behaves differently on Windows, and our target platform is Linux")
 @WebFluxTest(controllers = [AgentsController::class])  // to autowire everything for DockerService
 @MockBeans(
-    MockBean(AgentService::class)
+    MockBean(AgentService::class),
+    MockBean(MeterRegistry::class),
 )
 @Import(Beans::class, DockerService::class)
 class DockerServiceTest {

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/testutils/TestConfiguration.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/testutils/TestConfiguration.kt
@@ -1,0 +1,13 @@
+package org.cqfn.save.orchestrator.testutils
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@Suppress("MISSING_KDOC_TOP_LEVEL", "MISSING_KDOC_CLASS_ELEMENTS", "MISSING_KDOC_ON_FUNCTION")
+class TestConfiguration {
+    @Bean
+    fun meterRegistry(): MeterRegistry = CompositeMeterRegistry()
+}


### PR DESCRIPTION
* Measure time of `docker build` command. Will be useful when we need to tune performance in the future.

Related to #344

```
# HELP save_orchestrator_docker_build_seconds_max  
# TYPE save_orchestrator_docker_build_seconds_max gauge
save_orchestrator_docker_build_seconds_max{baseImage="openjdk:11",cmd="BuildImageCmd",} 13.381837036
# HELP save_orchestrator_docker_build_seconds  
# TYPE save_orchestrator_docker_build_seconds summary
save_orchestrator_docker_build_seconds_count{baseImage="openjdk:11",cmd="BuildImageCmd",} 1.0
save_orchestrator_docker_build_seconds_sum{baseImage="openjdk:11",cmd="BuildImageCmd",} 13.381837036
```