### PR TITLE
Improvements for ProjectPermissionEvaluator

### DIFF
--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/LnkUserProjectRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/LnkUserProjectRepository.kt
@@ -14,4 +14,6 @@ interface LnkUserProjectRepository : BaseEntityRepository<LnkUserProject> {
      * @return lnkUserProject by project
      */
     fun findByProject(project: Project): List<LnkUserProject>
+
+    fun findByUserIdAndProject(userId: Long, project: Project): List<LnkUserProject>
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/LnkUserProjectRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/LnkUserProjectRepository.kt
@@ -15,5 +15,10 @@ interface LnkUserProjectRepository : BaseEntityRepository<LnkUserProject> {
      */
     fun findByProject(project: Project): List<LnkUserProject>
 
+    /**
+     * @param userId
+     * @param project
+     * @return lnkUserProject by user ID and project
+     */
     fun findByUserIdAndProject(userId: Long, project: Project): List<LnkUserProject>
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/LnkUserProjectService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/LnkUserProjectService.kt
@@ -19,6 +19,11 @@ class LnkUserProjectService(private val lnkUserProjectRepository: LnkUserProject
         .filter { it.role == role }
         .map { it.user }
 
+    /**
+     * @param userId
+     * @param project
+     * @return role for user in [project] by user ID
+     */
     fun findRoleByUserIdAndProject(userId: Long, project: Project) = lnkUserProjectRepository.findByUserIdAndProject(userId, project)
         .map { it.role }
         .ifEmpty { listOf(Role.VIEWER) }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/LnkUserProjectService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/LnkUserProjectService.kt
@@ -18,4 +18,10 @@ class LnkUserProjectService(private val lnkUserProjectRepository: LnkUserProject
     fun getAllUsersByProjectAndRole(project: Project, role: Role) = lnkUserProjectRepository.findByProject(project)
         .filter { it.role == role }
         .map { it.user }
+
+    fun findRoleByUserIdAndProject(userId: Long, project: Project) = lnkUserProjectRepository.findByUserIdAndProject(userId, project)
+        .map { it.role }
+        .ifEmpty { listOf(Role.VIEWER) }
+        .singleOrNull()
+        ?: throw IllegalStateException("Multiple roles are set for userId=$userId and project=$project")
 }

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -86,6 +86,22 @@ class ProjectPermissionEvaluatorTest {
     }
 
     @Test
+    fun `permissions for project admins`() {
+        userShouldHavePermissions(
+            "super_admin", Role.SUPER_ADMIN, listOf(Role.ADMIN), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "admin", Role.ADMIN, listOf(Role.ADMIN), Permission.READ, Permission.WRITE, userId = 99
+        )
+        userShouldHavePermissions(
+            "owner", Role.OWNER, listOf(Role.ADMIN), Permission.READ, Permission.WRITE, userId = 99
+        )
+        userShouldHavePermissions(
+            "viewer", Role.VIEWER, listOf(Role.ADMIN), Permission.READ, Permission.WRITE, userId = 99
+        )
+    }
+
+    @Test
     fun `permissions for project viewers`() {
         userShouldHavePermissions(
             "super_admin", Role.SUPER_ADMIN, listOf(Role.VIEWER), *Permission.values(), userId = 99

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -1,0 +1,45 @@
+package org.cqfn.save.backend.security
+
+import org.cqfn.save.backend.repository.LnkUserProjectRepository
+import org.cqfn.save.backend.service.LnkUserProjectService
+import org.cqfn.save.backend.utils.AuthenticationDetails
+import org.cqfn.save.domain.Role
+import org.cqfn.save.entities.Project
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class, MockitoExtension::class)
+@Import(ProjectPermissionEvaluator::class, LnkUserProjectService::class)
+class ProjectPermissionEvaluatorTest {
+    @Autowired private lateinit var projectPermissionEvaluator: ProjectPermissionEvaluator
+    @MockBean private lateinit var lnkUserProjectRepository: LnkUserProjectRepository
+    private var mockProject = Project.stub(99)
+
+    @Test
+    fun `should allow any operations for SUPER_ADMIN`() {
+        val auth = mockAuth("admin", Role.SUPER_ADMIN.asSpringSecurityRole())
+        whenever(lnkUserProjectRepository.findByUserIdAndProject(any(), any())).thenReturn(emptyList())
+        Assertions.assertTrue(projectPermissionEvaluator.hasPermission(auth, mockProject, Permission.READ))
+        Assertions.assertTrue(projectPermissionEvaluator.hasPermission(auth, mockProject, Permission.WRITE))
+        Assertions.assertTrue(projectPermissionEvaluator.hasPermission(auth, mockProject, Permission.DELETE))
+    }
+
+    private fun mockAuth(principal: String, vararg roles: String, id: Long = 99) = UsernamePasswordAuthenticationToken(
+        principal,
+        "",
+        roles.map { SimpleGrantedAuthority(it) }
+    ).apply {
+        details = AuthenticationDetails(id = id, identitySource = "")
+    }
+}

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -68,13 +68,65 @@ class ProjectPermissionEvaluatorTest {
         )
     }
 
+    @Test
+    fun `permissions for project owners`() {
+        mockProject.userId = 99
+        userShouldHavePermissions(
+            "super_admin", Role.SUPER_ADMIN, listOf(Role.OWNER), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "admin", Role.ADMIN, listOf(Role.OWNER), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "owner", Role.OWNER, listOf(Role.OWNER), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "viewer", Role.VIEWER, listOf(Role.OWNER), *Permission.values(), userId = 99
+        )
+    }
+
+    @Test
+    fun `permissions for project viewers`() {
+        userShouldHavePermissions(
+            "super_admin", Role.SUPER_ADMIN, listOf(Role.VIEWER), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "admin", Role.ADMIN, listOf(Role.VIEWER), Permission.READ, userId = 99
+        )
+        userShouldHavePermissions(
+            "owner", Role.OWNER, listOf(Role.VIEWER), Permission.READ, userId = 99
+        )
+        userShouldHavePermissions(
+            "viewer", Role.VIEWER, listOf(Role.VIEWER), Permission.READ, userId = 99
+        )
+    }
+
+    @Test
+    fun `permissions for organization owners`() {
+        mockProject.organization.ownerId = 99
+        userShouldHavePermissions(
+            "super_admin", Role.SUPER_ADMIN, emptyList(), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "admin", Role.ADMIN, emptyList(), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "owner", Role.OWNER, emptyList(), *Permission.values(), userId = 99
+        )
+        userShouldHavePermissions(
+            "viewer", Role.VIEWER, emptyList(), *Permission.values(), userId = 99
+        )
+    }
+
+
     private fun userShouldHavePermissions(
         username: String,
         role: Role,
         projectRoles: List<Role>,
         vararg permissions: Permission,
+        userId: Long = 1
     ) {
-        val authentication = mockAuth(username, role.asSpringSecurityRole())
+        val authentication = mockAuth(username, role.asSpringSecurityRole(), id = userId)
         whenever(lnkUserProjectRepository.findByUserIdAndProject(any(), any())).thenAnswer { invocation ->
             projectRoles.map { role ->
                 LnkUserProject(

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -4,8 +4,11 @@ import org.cqfn.save.backend.repository.LnkUserProjectRepository
 import org.cqfn.save.backend.service.LnkUserProjectService
 import org.cqfn.save.backend.utils.AuthenticationDetails
 import org.cqfn.save.domain.Role
+import org.cqfn.save.entities.LnkUserProject
 import org.cqfn.save.entities.Project
+import org.cqfn.save.entities.User
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -16,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
@@ -24,15 +28,72 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 class ProjectPermissionEvaluatorTest {
     @Autowired private lateinit var projectPermissionEvaluator: ProjectPermissionEvaluator
     @MockBean private lateinit var lnkUserProjectRepository: LnkUserProjectRepository
-    private var mockProject = Project.stub(99)
+    private lateinit var mockProject: Project
+
+    @BeforeEach
+    fun setUp() {
+        mockProject = Project.stub(99)
+    }
 
     @Test
-    fun `should allow any operations for SUPER_ADMIN`() {
-        val auth = mockAuth("admin", Role.SUPER_ADMIN.asSpringSecurityRole())
-        whenever(lnkUserProjectRepository.findByUserIdAndProject(any(), any())).thenReturn(emptyList())
-        Assertions.assertTrue(projectPermissionEvaluator.hasPermission(auth, mockProject, Permission.READ))
-        Assertions.assertTrue(projectPermissionEvaluator.hasPermission(auth, mockProject, Permission.WRITE))
-        Assertions.assertTrue(projectPermissionEvaluator.hasPermission(auth, mockProject, Permission.DELETE))
+    fun `default permissions for users with only global roles`() {
+        userShouldHavePermissions(
+            "super_admin", Role.SUPER_ADMIN, emptyList(), *Permission.values()
+        )
+        userShouldHavePermissions(
+            "admin", Role.ADMIN, emptyList(), Permission.READ
+        )
+        userShouldHavePermissions(
+            "owner", Role.OWNER, emptyList(), Permission.READ
+        )
+        userShouldHavePermissions(
+            "viewer", Role.VIEWER, emptyList(), Permission.READ
+        )
+    }
+
+    @Test
+    fun `default permissions for users with only global roles for private projects`() {
+        mockProject.public = false
+        userShouldHavePermissions(
+            "super_admin", Role.SUPER_ADMIN, emptyList(), *Permission.values()
+        )
+        userShouldHavePermissions(
+            "admin", Role.ADMIN, emptyList()
+        )
+        userShouldHavePermissions(
+            "owner", Role.OWNER, emptyList()
+        )
+        userShouldHavePermissions(
+            "viewer", Role.VIEWER, emptyList()
+        )
+    }
+
+    private fun userShouldHavePermissions(
+        username: String,
+        role: Role,
+        projectRoles: List<Role>,
+        vararg permissions: Permission,
+    ) {
+        val authentication = mockAuth(username, role.asSpringSecurityRole())
+        whenever(lnkUserProjectRepository.findByUserIdAndProject(any(), any())).thenAnswer { invocation ->
+            projectRoles.map { role ->
+                LnkUserProject(
+                    invocation.arguments[1] as Project,
+                    mockUser((invocation.arguments[0] as Number).toLong()),
+                    role,
+                )
+            }
+        }
+        permissions.forEach {
+            Assertions.assertTrue(projectPermissionEvaluator.hasPermission(authentication, mockProject, it)) {
+                "User by authentication=$authentication is expected to have permission $it on project $mockProject"
+            }
+        }
+        Permission.values().filterNot { it in permissions }.forEach {
+            Assertions.assertFalse(projectPermissionEvaluator.hasPermission(authentication, mockProject, it)) {
+                "User by authentication=$authentication isn't expected to have permission $it on project $mockProject"
+            }
+        }
     }
 
     private fun mockAuth(principal: String, vararg roles: String, id: Long = 99) = UsernamePasswordAuthenticationToken(
@@ -42,4 +103,6 @@ class ProjectPermissionEvaluatorTest {
     ).apply {
         details = AuthenticationDetails(id = id, identitySource = "")
     }
+
+    private fun mockUser(id: Long) = User(null, null, null, "").apply { this.id = id }
 }

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/security/ProjectPermissionEvaluatorTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
@@ -19,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
@@ -133,7 +131,6 @@ class ProjectPermissionEvaluatorTest {
             "viewer", Role.VIEWER, emptyList(), *Permission.values(), userId = 99
         )
     }
-
 
     private fun userShouldHavePermissions(
         username: String,


### PR DESCRIPTION
* Check if the user is project's organization owner
* Use project role instead of list of users with role
* Unit tests for `ProjectPermissionEvaluator`