### PR TITLE
Extract some spring boot annotations into `ApplicationConfiguration` class

### DIFF
--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/SaveApplication.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/SaveApplication.kt
@@ -2,14 +2,9 @@ package org.cqfn.save.backend
 
 import org.cqfn.save.backend.configs.ConfigProperties
 import org.springframework.boot.SpringApplication
-import org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa.HibernateMetricsAutoConfiguration
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.http.ResponseEntity
-import org.springframework.web.reactive.config.EnableWebFlux
 
 typealias ByteArrayResponse = ResponseEntity<ByteArray>
 typealias StringResponse = ResponseEntity<String>
@@ -19,11 +14,7 @@ typealias EmptyResponse = ResponseEntity<Void>
  * An entrypoint for spring for save-backend
  */
 @SpringBootApplication
-@EnableWebFlux
-@EnableJpaRepositories(basePackages = ["org.cqfn.save.backend.repository"])
-@EntityScan("org.cqfn.save.entities")
 @EnableConfigurationProperties(ConfigProperties::class)
-@ImportAutoConfiguration(HibernateMetricsAutoConfiguration::class)
 class SaveApplication
 
 fun main(args: Array<String>) {

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/ApplicationConfiguration.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/ApplicationConfiguration.kt
@@ -1,0 +1,16 @@
+package org.cqfn.save.backend.configs
+
+import org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa.HibernateMetricsAutoConfiguration
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.web.reactive.config.EnableWebFlux
+
+@Configuration
+@EnableWebFlux
+@EnableJpaRepositories(basePackages = ["org.cqfn.save.backend.repository"])
+@EntityScan("org.cqfn.save.entities")
+@ImportAutoConfiguration(HibernateMetricsAutoConfiguration::class)
+@Suppress("MISSING_KDOC_TOP_LEVEL")
+class ApplicationConfiguration

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/DatabaseTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/DatabaseTest.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.backend
 
 import org.cqfn.save.agent.AgentState
+import org.cqfn.save.backend.configs.ApplicationConfiguration
 import org.cqfn.save.backend.repository.AgentStatusRepository
 import org.cqfn.save.backend.repository.ProjectRepository
 import org.cqfn.save.backend.repository.TestExecutionRepository
@@ -12,7 +13,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
 
+@Import(ApplicationConfiguration::class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ExtendWith(MySqlExtension::class)

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
@@ -4,9 +4,7 @@ import org.cqfn.save.backend.configs.ConfigProperties
 import org.cqfn.save.backend.configs.NoopWebSecurityConfig
 import org.cqfn.save.backend.configs.WebConfig
 import org.cqfn.save.backend.controllers.DownloadFilesController
-import org.cqfn.save.backend.controllers.OrganizationController
 import org.cqfn.save.backend.repository.*
-import org.cqfn.save.backend.scheduling.StandardSuitesUpdateScheduler
 import org.cqfn.save.backend.service.OrganizationService
 import org.cqfn.save.core.result.DebugInfo
 import org.cqfn.save.core.result.Pass
@@ -60,20 +58,7 @@ import kotlin.io.path.writeLines
 @AutoConfigureWebTestClient
 @EnableConfigurationProperties(ConfigProperties::class)
 @MockBeans(
-    MockBean(AgentStatusRepository::class),
-    MockBean(ExecutionRepository::class),
     MockBean(OrganizationService::class),
-    MockBean(OrganizationRepository::class),
-    MockBean(OrganizationController::class),
-    MockBean(ProjectRepository::class),
-    MockBean(TestExecutionRepository::class),
-    MockBean(TestRepository::class),
-    MockBean(TestSuiteRepository::class),
-    MockBean(GitRepository::class),
-    MockBean(StandardSuitesUpdateScheduler::class),
-    MockBean(UserRepository::class),
-    MockBean(AwesomeBenchmarksRepository::class),
-    MockBean(LnkUserProjectRepository::class),
 )
 class DownloadFilesTest {
     @Autowired

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
@@ -4,12 +4,9 @@ import org.cqfn.save.backend.configs.ConfigProperties
 import org.cqfn.save.backend.configs.WebConfig
 import org.cqfn.save.backend.configs.WebSecurityConfig
 import org.cqfn.save.backend.controllers.CloneRepositoryController
-import org.cqfn.save.backend.controllers.OrganizationController
 import org.cqfn.save.backend.repository.*
-import org.cqfn.save.backend.scheduling.StandardSuitesUpdateScheduler
 import org.cqfn.save.backend.security.ProjectPermissionEvaluator
 import org.cqfn.save.backend.service.ExecutionService
-import org.cqfn.save.backend.service.OrganizationService
 import org.cqfn.save.backend.service.ProjectService
 import org.cqfn.save.backend.service.UserDetailsService
 import org.cqfn.save.backend.utils.ConvertingAuthenticationManager
@@ -66,23 +63,9 @@ import kotlin.io.path.createFile
 @EnableConfigurationProperties(ConfigProperties::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @MockBeans(
-    MockBean(AgentStatusRepository::class),
-    MockBean(AgentRepository::class),
-    MockBean(ExecutionRepository::class),
     MockBean(ExecutionService::class),
-    MockBean(TestExecutionRepository::class),
-    MockBean(TestRepository::class),
-    MockBean(TestSuiteRepository::class),
-    MockBean(ProjectRepository::class),
-    MockBean(GitRepository::class),
-    MockBean(StandardSuitesUpdateScheduler::class),
-    MockBean(UserRepository::class),
-    MockBean(AwesomeBenchmarksRepository::class),
-    MockBean(OrganizationRepository::class),
-    MockBean(OrganizationController::class),
-    MockBean(OrganizationService::class),
-    MockBean(LnkUserProjectRepository::class),
     MockBean(ProjectPermissionEvaluator::class),
+    MockBean(UserRepository::class),
 )
 @Suppress("TOO_LONG_FUNCTION")
 class CloningRepositoryControllerTest {

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/JpaSpecificationTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/JpaSpecificationTest.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.backend.controller
 
 import org.cqfn.save.agent.AgentState
+import org.cqfn.save.backend.configs.ApplicationConfiguration
 import org.cqfn.save.backend.repository.AgentStatusRepository
 import org.cqfn.save.backend.utils.MySqlExtension
 import org.junit.jupiter.api.Assertions
@@ -9,7 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
 
+@Import(ApplicationConfiguration::class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ExtendWith(MySqlExtension::class)


### PR DESCRIPTION
This removes necessity to mock all repositories in simple `@WebFluxTest` tests.