### PR TITLE
Add custom error page in backend

### DIFF
--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
@@ -57,7 +57,12 @@ class WebSecurityConfig(
         )
     ).authorizeExchange { authorizeExchangeSpec ->
         // this is default data that is required by FE to operate properly
-        authorizeExchangeSpec.pathMatchers("/", "/login", "/logout", "/sec/oauth-providers", "/sec/user")
+        authorizeExchangeSpec.pathMatchers(
+            "/",
+            "/login", "/logout",
+            "/sec/oauth-providers", "/sec/user",
+            "/error",
+        )
             .permitAll()
             // all requests to backend are permitted on gateway, if user agent is authenticated in gateway or doesn't have
             // any authentication data at all.
@@ -79,7 +84,7 @@ class WebSecurityConfig(
                 }
             }
             // resources for frontend
-            .pathMatchers("/*.html", "/*.js*", "/img/**")
+            .pathMatchers("/*.html", "/*.js*", "/*.css", "/img/**")
             .permitAll()
     }
         .run {

--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
@@ -84,7 +84,7 @@ class WebSecurityConfig(
                 }
             }
             // resources for frontend
-            .pathMatchers("/*.html", "/*.js*", "/*.css", "/img/**")
+            .pathMatchers("/*.html", "/*.js*", "/*.css", "/img/**", "favicon.ico")
             .permitAll()
     }
         .run {

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
   port: 5300
+  error:
+    path: /error
 gateway:
   backend:
     url: http://backend:5000
@@ -29,10 +31,14 @@ spring:
           filters:
             # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
             - RemoveRequestHeader=Cookie
+        - id: error_route
+          uri: http://backend:5000/error
+          predicates:
+            - Path=/error
         - id: resource_route
           uri: http://backend:5000
           predicates:
-            - Path=/*.html,/*.js*,/img/**
+            - Path=/*.html,/*.js*,/*.css,/img/**
           filters:
             # If SESSION cookie is passed to downstream, it is then removed, because downstream discards it
             - RemoveRequestHeader=Cookie

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
@@ -32,7 +32,8 @@ class WebConfiguration(
     }
 
     /**
-     * @param indexPage requested resource
+     * @param indexPage resource for index.html
+     * @param errorPage resource for error.html
      * @return router bean
      */
     @Bean

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
@@ -32,13 +32,20 @@ class WebConfiguration(
     }
 
     /**
-     * @param html requested resource
+     * @param indexPage requested resource
      * @return router bean
      */
     @Bean
-    fun indexRouter(@Value("classpath:/static/index.html") html: Resource) = router {
+    fun indexRouter(
+        @Value("classpath:/static/index.html") indexPage: Resource,
+        @Value("classpath:/static/error.html") errorPage: Resource,
+    ) = router {
         GET("/") {
-            ok().header("Content-Type", "text/html; charset=utf8").bodyValue(html)
+            ok().header("Content-Type", "text/html; charset=utf8").bodyValue(indexPage)
+        }
+
+        GET("/error") {
+            ok().header("Content-Type", "text/html; charset=utf8").bodyValue(errorPage)
         }
     }
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebSecurityConfig.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebSecurityConfig.kt
@@ -46,7 +46,7 @@ class WebSecurityConfig(
             .pathMatchers("/", "/internal/**", "/actuator/**", *publicEndpoints.toTypedArray())
             .permitAll()
             // resources for frontend
-            .pathMatchers("/*.html", "/*.js*", "/img/**")
+            .pathMatchers("/*.html", "/*.js*", "/*.css", "/img/**", "favicon.ico")
             .permitAll()
     }
         .and().run {
@@ -97,6 +97,7 @@ class WebSecurityConfig(
          * Or we can use custom AccessDecisionManager later.
          */
         internal val publicEndpoints = listOf(
+            "/error",
             // `CollectionView` is a public page
             "/api/projects/not-deleted",
             "/api/awesome-benchmarks",

--- a/save-backend/src/main/resources/application.properties
+++ b/save-backend/src/main/resources/application.properties
@@ -2,6 +2,7 @@ backend.preprocessorUrl=http://preprocessor:5200
 backend.initialBatchSize=100
 backend.fileStorage.location=/home/cnb/files
 server.port = 5000
+server.error.path=/error
 management.endpoints.web.exposure.include=health,info,prometheus,quartz
 spring.profiles.default=dev,secure
 springdoc.api-docs.path=/internal/v3/api-docs

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/service/PermissionServiceTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/service/PermissionServiceTest.kt
@@ -79,7 +79,7 @@ class PermissionServiceTest {
     }
 
     private fun PermissionService.getRole(userName: String, projectName: String, organizationName: String): Mono<Role> =
-             findUserAndProject(userName, organizationName, projectName).map { (user, project) ->
+            findUserAndProject(userName, organizationName, projectName).map { (user, project) ->
                 getRole(user, project)
             }
 }

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
             compileOnly(devNpm("postcss", "^8.2.13"))
             compileOnly(devNpm("autoprefixer", ">9"))
             compileOnly(devNpm("webpack-bundle-analyzer", "*"))
+            compileOnly(devNpm("mini-css-extract-plugin", "^2.6.0"))
 
             // web-specific dependencies
             implementation(npm("@fortawesome/fontawesome-svg-core", "^1.2.36"))

--- a/save-frontend/src/main/resources/error.html
+++ b/save-frontend/src/main/resources/error.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>SAVE Cloud Service</title>
+
+    <link rel="stylesheet" type="text/css" href="main.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <!-- Custom fonts for this template-->
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+</head>
+
+<body id="page-top">
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.min.js" integrity="sha384-VHvPCCyXqtD5DqJeNxl2dtTyhF78xXNXdkwX1CZeRusQfRKp+tA7hAShOK/B/fQ2" crossorigin="anonymous"></script>
+<div class="d-flex flex-column">
+    <div class="text-center">
+        <div class="error mx-auto" data-text="Error">Error</div>
+        <p class="lead text-gray-800 mb-5">Something went wrong on our side. Please try again later or report this issue
+            on <a href="https://github.com/analysis-dev/save-cloud/issues">our github</a>.</p>
+    </div>
+</div>
+
+</body>
+</html>

--- a/save-frontend/src/main/resources/index.html
+++ b/save-frontend/src/main/resources/index.html
@@ -10,6 +10,7 @@
 
     <title>SAVE Cloud Service</title>
 
+    <link rel="stylesheet" type="text/css" href="main.css"/>
     <!-- Custom fonts for this template-->
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">

--- a/save-frontend/webpack.config.d/css.js
+++ b/save-frontend/webpack.config.d/css.js
@@ -1,8 +1,10 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
 config.module.rules.push(
     {
         test: /\.scss$/,
         use: [
-            'style-loader', // creates style nodes from JS strings
+            MiniCssExtractPlugin.loader,  // creates CSS files from css-loader's output
             'css-loader', // translates CSS into CommonJS
             {
                 loader: 'postcss-loader', // Run postcss actions
@@ -32,3 +34,7 @@ config.module.rules.push(
         }
     }
 );
+
+config.plugins.push(
+    new MiniCssExtractPlugin()
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,6 +2106,13 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mini-css-extract-plugin@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.0.tgz#578aebc7fc14d32c0ad304c2c34f08af44673f5e"
+  integrity sha512-ndG8nxCEnAemsg4FSgS+yNyHKgkTB4nPKqCOgh65j3/30qqC5RaSQQXMm++Y6sb6E1zRSxPkztj9fqxhS1Eo6w==
+  dependencies:
+    schema-utils "^4.0.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"


### PR DESCRIPTION
* Backend: Add `error.html` and custom error endpoint for spring boot
* Frontend: Change `style-loader` (embeds CSS into JS) to [`mini-css-extract-plugin`](https://webpack.js.org/plugins/mini-css-extract-plugin/)(saves CSS into a separate file), use separate css file instead of bundled into JS
* Gateway: Add custom error endpoint, which delegates to backend's `/error`

Closes #409. After this we can make a dedicated login error page for #626 in a similar way.

![image](https://user-images.githubusercontent.com/23018090/159734010-bb2bb2a8-2441-428d-a263-ef40cc7a95d7.png)
