### PR TITLE
Display a single error modal on non-ok response statuses

### DIFF
--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
@@ -81,6 +81,7 @@ external interface TableProps : Props {
     "TOO_LONG_FUNCTION",
     "TOO_MANY_PARAMETERS",
     "TYPE_ALIAS",
+    "ComplexMethod",
     "ForbiddenComment",
     "LongMethod",
     "LongParameterList",

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/tables/TableComponent.kt
@@ -8,10 +8,11 @@ package org.cqfn.save.frontend.components.tables
 
 import org.cqfn.save.frontend.components.errorStatusContext
 import org.cqfn.save.frontend.components.modal.errorModal
+import org.cqfn.save.frontend.http.HttpStatusException
 import org.cqfn.save.frontend.utils.WithRequestStatusContext
 import org.cqfn.save.frontend.utils.spread
 
-import react.PropsWithChildren
+import react.Props
 import react.RBuilder
 import react.dom.RDOMBuilder
 import react.dom.div
@@ -50,9 +51,9 @@ import kotlinx.html.THEAD
 import kotlinx.js.jso
 
 /**
- * [RProps] of a data table
+ * [Props] of a data table
  */
-external interface TableProps : PropsWithChildren {
+external interface TableProps : Props {
     /**
      * Table header
      */
@@ -150,7 +151,11 @@ fun <D : Any> tableComponent(
             } catch (e: CancellationException) {
                 // this means, that view is re-rendering while network request was still in progress
                 // no need to display an error message in this case
+            } catch (e: HttpStatusException) {
+                // this is a normal situation which should be handled by responseHandler in `getData` itself.
+                // no need to display an error message in this case
             } catch (e: Exception) {
+                // other exceptions are not handled by `responseHandler` and should be displayed separately
                 setIsModalOpen(true)
                 setDataAccessException(e)
             }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/http/Exceptions.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/http/Exceptions.kt
@@ -1,0 +1,20 @@
+/**
+ * Exception types for frontend
+ */
+
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package org.cqfn.save.frontend.http
+
+/**
+ * Exception class for HTTP responses until we use a dedicated HTTP client
+ *
+ * @property status response status
+ * @property statusText response status text
+ */
+data class HttpStatusException(
+    val status: Short,
+    val statusText: String,
+) : RuntimeException() {
+    override val message: String = "$status $statusText"
+}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/RequestUtils.kt
@@ -7,6 +7,7 @@
 package org.cqfn.save.frontend.utils
 
 import org.cqfn.save.frontend.components.errorStatusContext
+import org.cqfn.save.frontend.http.HttpStatusException
 
 import org.w3c.fetch.Headers
 import org.w3c.fetch.RequestCredentials
@@ -50,7 +51,7 @@ fun interface WithRequestStatusContext {
 suspend fun <T> Response.unsafeMap(map: suspend (Response) -> T) = if (this.ok) {
     map(this)
 } else {
-    error("$status $statusText")
+    throw HttpStatusException(status, statusText)
 }
 
 /**


### PR DESCRIPTION
Because displaying non-ok response statuses is now embedded into request methods, it it not necessary to have an additional handler in TableComponent. For other data access exceptions, which can possibly occur, we still need it, though.