### PR TITLE
Configs for more flexible deployment

### DIFF
--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/config/ConfigurationProperties.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/config/ConfigurationProperties.kt
@@ -7,14 +7,12 @@ import java.net.InetAddress
 
 /**
  * @property backend properties for connection to save-backend
- * @property basicCredentials space-separated username and password for technical user to access actuator
  * @property knownActuatorConsumers comma-separated list of IPs of clients that are allowed to access spring boot actuator
  */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "gateway")
 data class ConfigurationProperties(
     val backend: Backend,
-    val basicCredentials: String?,
     val knownActuatorConsumers: String?,
 ) {
     /**

--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
@@ -171,6 +171,7 @@ class WebSecurityConfig(
     fun actuatorSecurityWebFilterChain(
         http: ServerHttpSecurity
     ): SecurityWebFilterChain = http.run {
+        // Allow access to actuator only from a set of addresses or subnets, without any additional checks.
         authorizeExchange()
             .matchers(
                 AndServerWebExchangeMatcher(

--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
@@ -21,9 +21,7 @@ import org.springframework.security.authorization.AuthenticatedReactiveAuthoriza
 import org.springframework.security.authorization.AuthorizationDecision
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
-import org.springframework.security.core.userdetails.MapReactiveUserDetailsService
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService
-import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.crypto.factory.PasswordEncoderFactories
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -185,7 +183,7 @@ class WebSecurityConfig(
                     }
                 )
             )
-                .permitAll()
+            .permitAll()
     }
         .and().build()
 

--- a/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
+++ b/api-gateway/src/main/kotlin/org/cqfn/save/gateway/security/WebSecurityConfig.kt
@@ -185,22 +185,8 @@ class WebSecurityConfig(
                     }
                 )
             )
-            .authenticated()
+                .permitAll()
     }
-        .and().httpBasic().run {
-            val userFromProps = configurationProperties.basicCredentials?.split(' ')?.run {
-                User(first(), last(), emptyList())
-            }
-            if (userFromProps != null) {
-                authenticationManager(
-                    UserDetailsRepositoryReactiveAuthenticationManager(
-                        MapReactiveUserDetailsService(userFromProps)
-                    )
-                )
-            } else {
-                this
-            }
-        }
         .and().build()
 
     private fun matchAllExcludingActuator() = AndServerWebExchangeMatcher(

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
@@ -19,10 +19,11 @@ class DockerSecretsDatabaseProcessor : EnvironmentPostProcessor {
     private val log = LoggerFactory.getLogger(DockerSecretsDatabaseProcessor::class.java)
 
     override fun postProcessEnvironment(environment: ConfigurableEnvironment?, application: SpringApplication?) {
-        log.debug("Started DockerSecretsDatabaseProcessor [EnvironmentPostProcessor]")
-        val passwordResource = FileSystemResource("/run/secrets/db_password")
-        val usernameResource = FileSystemResource("/run/secrets/db_username")
-        val jdbcUrlResource = FileSystemResource("/run/secrets/db_url")
+        val secretsBasePath = System.getenv("DB_PASSWORD_FILE") ?: "/run/secrets"
+        log.debug("Started DockerSecretsDatabaseProcessor [EnvironmentPostProcessor] configured to look up secrets in $secretsBasePath")
+        val passwordResource = FileSystemResource("$secretsBasePath/db_password")
+        val usernameResource = FileSystemResource("$secretsBasePath/db_username")
+        val jdbcUrlResource = FileSystemResource("$secretsBasePath/db_url")
 
         if (passwordResource.exists()) {
             log.debug("Acquired password. Beginning to setting properties")

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
@@ -18,7 +18,7 @@ import java.util.Properties
 class DockerSecretsDatabaseProcessor : EnvironmentPostProcessor {
     private val log = LoggerFactory.getLogger(DockerSecretsDatabaseProcessor::class.java)
 
-    override fun postProcessEnvironment(environment: ConfigurableEnvironment?, application: SpringApplication?) {
+    override fun postProcessEnvironment(environment: ConfigurableEnvironment, application: SpringApplication) {
         val secretsBasePath = System.getenv("DB_PASSWORD_FILE") ?: "/run/secrets"
         log.debug("Started DockerSecretsDatabaseProcessor [EnvironmentPostProcessor] configured to look up secrets in $secretsBasePath")
         val passwordResource = FileSystemResource("$secretsBasePath/db_password")
@@ -27,14 +27,14 @@ class DockerSecretsDatabaseProcessor : EnvironmentPostProcessor {
 
         if (passwordResource.exists()) {
             log.debug("Acquired password. Beginning to setting properties")
-            val dbPassword = StreamUtils.copyToString(passwordResource.inputStream, Charset.defaultCharset())
-            val dbUsername = StreamUtils.copyToString(usernameResource.inputStream, Charset.defaultCharset())
-            val dbUrl = StreamUtils.copyToString(jdbcUrlResource.inputStream, Charset.defaultCharset())
+            val dbPassword = passwordResource.inputStream.use { StreamUtils.copyToString(it, Charset.defaultCharset()) }
+            val dbUsername = usernameResource.inputStream.use { StreamUtils.copyToString(it, Charset.defaultCharset()) }
+            val dbUrl = jdbcUrlResource.inputStream.use { StreamUtils.copyToString(it, Charset.defaultCharset()) }
             val props = Properties()
             props["spring.datasource.password"] = dbPassword
             props["spring.datasource.username"] = dbUsername
             props["spring.datasource.url"] = dbUrl
-            environment?.propertySources?.addLast(PropertiesPropertySource("dbProps", props))
+            environment.propertySources.addLast(PropertiesPropertySource("dbProps", props))
             log.debug("Properties have been set")
         }
     }


### PR DESCRIPTION
* Gateway/actuator: Don't check password if subnet matches (checking request origin is enough of a security measure, and also authenticated health checks are not supported well enough in Kubernetes)
* Backend/postprocessor: Read secrets base path from env. A bit of un-hardcoding paths from env postprocessor to allow more flexible configuration in other environemtns

Fixme (that we kind of forgot about): logs from postprocessor are not visible, see https://stackoverflow.com/a/42840529