### PR TITLE
Backend: set `Cache-Control` for static resources

### DIFF
--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
@@ -31,14 +31,18 @@ class WebConfiguration(
     fun staticResourceRouter() = router {
         GET("/{*resourcePath}") {
             val resourcePath = it.pathVariable("resourcePath")
-            val resource = ClassPathResource("static/$resourcePath")
+            val resource = if (resourcePath.isNotBlank() && resourcePath != "/") {
+                ClassPathResource("static/$resourcePath")
+            } else {
+                ClassPathResource("static/index.html")
+            }
             val cacheControl: (ServerResponse.BodyBuilder) -> ServerResponse.BodyBuilder = when (resource.file.extension) {
                 "js" -> { b -> b.cacheControl(10.minutes) { cachePublic() } }
                 "css" -> { b -> b.cacheControl(10.minutes) { cachePublic() } }
                 else -> { b -> b.cacheControl(CacheControl.noCache()) }
             }
             ok().run(cacheControl)
-                .bodyValue(resource)
+                .body(BodyInserters.fromResource(resource))
         }
     }
 

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
@@ -46,7 +46,7 @@ class WebConfiguration(
     }
 
     /**
-     * @return a router with router for avatars that sets `Cache-Control` header
+     * @return a router with routes for avatars that set `Cache-Control` header
      */
     @Bean
     fun staticImageResourceRouter() = router {

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/configs/WebConfiguration.kt
@@ -33,19 +33,8 @@ class WebConfiguration(
      * @return a router bean
      */
     @Bean
-    @Order(2)
     fun staticResourceRouter() = router {
-        GET("/{*resourcePath}") {
-            val resourcePath = it.pathVariable("resourcePath").runIf({ startsWith("/") }) { println("/"); drop(1) }
-            val resource = ClassPathResource("static/$resourcePath")
-            val cacheControl: (ServerResponse.BodyBuilder) -> ServerResponse.BodyBuilder = when (getFilenameExtension(resource.filename)) {
-                "js" -> { b -> b.cacheControl(10.minutes) { cachePublic() }.lastModified(resource.lastModified().toInstant()) }
-                "css" -> { b -> b.cacheControl(10.minutes) { cachePublic() } }
-                else -> { b -> b.cacheControl(CacheControl.noCache()) }
-            }
-            ok().run(cacheControl)
-                .bodyValue(resource)
-        }
+        resources("/**", ClassPathResource("static/"))
     }
 
     /**
@@ -69,7 +58,6 @@ class WebConfiguration(
      * @return router bean
      */
     @Bean
-    @Order(1)
     fun indexRouter(
         @Value("classpath:/static/index.html") indexPage: Resource,
         @Value("classpath:/static/error.html") errorPage: Resource,

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/utils/LongUtils.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/utils/LongUtils.kt
@@ -15,4 +15,7 @@ import java.time.ZoneOffset
  */
 fun Long.secondsToLocalDateTime(): LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(this), ZoneOffset.UTC)
 
+/**
+ * @return `Instant` representing this number of UNIX seconds
+ */
 fun Long.toInstant(): Instant = Instant.ofEpochSecond(this)

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/utils/LongUtils.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/utils/LongUtils.kt
@@ -14,3 +14,5 @@ import java.time.ZoneOffset
  * @return an instance of LocalDateTime
  */
 fun Long.secondsToLocalDateTime(): LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(this), ZoneOffset.UTC)
+
+fun Long.toInstant(): Instant = Instant.ofEpochSecond(this)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2004,7 +2004,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.debounce@4.0.8:
+lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=


### PR DESCRIPTION
* Support setting `Cache-Control` header for some resources served from backend
  * For `/api/avatars` it should work right away, because images with same name shouldn't be changed usually
  * For JS, CSS and HTML files we should use more fine-grained controls for caches, currently build timestamp is used as `Last-Modified` value