### PR TITLE
Integrate spring-cloud-kubernetes

### DIFF
--- a/api-gateway/build.gradle.kts
+++ b/api-gateway/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.spring.cloud.starter.gateway)
     implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.boot.starter.oauth2.client)
+    implementation(libs.spring.cloud.starter.kubernetes.client.config)
     implementation(libs.spring.security.core)
 }
 

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -46,6 +46,8 @@ spring:
           uri: http://grafana:9100
           predicates:
             - Path=/grafana/**
+    kubernetes:
+      enabled: false
   security:
     oauth2:
       client:
@@ -62,7 +64,7 @@ spring:
       on-profile: kubernetes
   cloud:
     kubernetes:
+      enabled: true
       secrets:
         enabled: true
-#        name: gateway-oauth-secrets  # can be consumed by name only with `enableApi: true`
-        paths: /home/cnb/secrets  # todo: better to use JAVA_OPTS?
+        paths: ${OAUTH_CONFIG_PATH}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -54,3 +54,15 @@ spring:
             # value that will work with GitHub API, where GitHub provides username as "login" in the response
             # https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
             user-name-attribute: login
+
+---
+spring:
+  config:
+    activate:
+      on-profile: kubernetes
+  cloud:
+    kubernetes:
+      secrets:
+        enabled: true
+#        name: gateway-oauth-secrets  # can be consumed by name only with `enableApi: true`
+        paths: /home/cnb/secrets  # todo: better to use JAVA_OPTS?

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -46,8 +46,6 @@ spring:
           uri: http://grafana:9100
           predicates:
             - Path=/grafana/**
-    kubernetes:
-      enabled: false
   security:
     oauth2:
       client:
@@ -56,15 +54,3 @@ spring:
             # value that will work with GitHub API, where GitHub provides username as "login" in the response
             # https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
             user-name-attribute: login
-
----
-spring:
-  config:
-    activate:
-      on-profile: kubernetes
-  cloud:
-    kubernetes:
-      enabled: true
-      secrets:
-        enabled: true
-        paths: ${OAUTH_CONFIG_PATH}

--- a/api-gateway/src/main/resources/bootstrap.yml
+++ b/api-gateway/src/main/resources/bootstrap.yml
@@ -1,0 +1,15 @@
+spring:
+  config:
+    activate:
+      on-profile: kubernetes
+  cloud:
+    kubernetes:
+      enabled: true
+      config:
+        # don't look up any ConfigMaps
+        enabled: false
+      secrets:
+        enabled: true
+        fail-fast: true
+        paths:
+        - ${OAUTH_CONFIG_PATH}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
   backend:
     image: ghcr.io/analysis-dev/save-backend:${TAG}
     environment:
-      - "SPRING_PROFILES_ACTIVE=${PROFILE},secure"
+      - "SPRING_PROFILES_ACTIVE=${PROFILE},secure,docker-secrets"
       - "MYSQL_USER=/run/secrets/db_username"
       - "MYSQL_PASSWORD_FILE=/run/secrets/db_password"
     secrets:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlin-wrappers = "0.0.1-pre.330-kotlin-1.6.20"
 spring-boot = "2.6.6"
 spring-security = "5.6.2"
 spring-cloud = "3.1.1"
+spring-cloud-kubernetes = "2.1.1"
 junit = "5.8.2"
 diktat = "1.1.0"
 detekt = "1.20.0"
@@ -85,6 +86,7 @@ spring-security-oauth2-client = { module = "org.springframework.security:spring-
 spring-security-test = { module = "org.springframework.security:spring-security-test", version.ref = "spring-security" }
 spring-boot-gradle-plugin = { module = "org.springframework.boot:spring-boot-gradle-plugin", version.ref = "spring-boot" }
 spring-cloud-starter-gateway = { module = "org.springframework.cloud:spring-cloud-starter-gateway", version.ref = "spring-cloud" }
+spring-cloud-starter-kubernetes-client-config = { module = "org.springframework.cloud:spring-cloud-starter-kubernetes-client-config", version.ref = "spring-cloud-kubernetes" }
 spring-boot-starter-oauth2-client = { module = "org.springframework.boot:spring-boot-starter-oauth2-client", version.ref = "spring-boot" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 

--- a/save-backend/build.gradle.kts
+++ b/save-backend/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.security.core)
     implementation(libs.hibernate.micrometer)
+    implementation(libs.spring.cloud.starter.kubernetes.client.config)
     testImplementation(libs.spring.security.test)
     testImplementation(projects.testUtils)
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
@@ -14,7 +14,7 @@ import java.util.Properties
 /**
  * Post processor that collects credentials for database from docker secrets
  */
-@Profile("prod")
+@Profile("docker-secrets")
 class DockerSecretsDatabaseProcessor : EnvironmentPostProcessor {
     private val log = LoggerFactory.getLogger(DockerSecretsDatabaseProcessor::class.java)
 

--- a/save-backend/src/main/resources/application-kubernetes.properties
+++ b/save-backend/src/main/resources/application-kubernetes.properties
@@ -1,0 +1,3 @@
+spring.cloud.kubernetes.enabled=true
+spring.cloud.kubernetes.secrets.enabled=true
+spring.cloud.kubernetes.secrets.paths=${DATABASE_SECRETS_PATH}

--- a/save-backend/src/main/resources/application.properties
+++ b/save-backend/src/main/resources/application.properties
@@ -15,3 +15,4 @@ spring.jpa.properties.hibernate.jdbc.batch_size=100
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
 logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=WARN
+spring.cloud.kubernetes.enabled=false

--- a/save-backend/src/main/resources/bootstrap-kubernetes.properties
+++ b/save-backend/src/main/resources/bootstrap-kubernetes.properties
@@ -1,3 +1,4 @@
 spring.cloud.kubernetes.enabled=true
+spring.cloud.kubernetes.config.enabled=false
 spring.cloud.kubernetes.secrets.enabled=true
 spring.cloud.kubernetes.secrets.paths=${DATABASE_SECRETS_PATH}

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
@@ -20,25 +20,6 @@ fun getHostIp(): String? {
 }
 
 /**
- * @param hostname hostname to be resolved via `hosts` file
- * @return IP address of [hostname] if it has been found or null
- */
-private fun resolve(hostname: String): String? {
-    val process = ProcessBuilder(
-        "bash", "-c",
-        "getent hosts $hostname | awk '{print \$1}'"
-    )
-        .start()
-    process.waitFor()
-    return process.inputStream
-        .readAllBytes()
-        .decodeToString()
-        .lines()
-        .firstOrNull()
-        ?.takeIf { it.isNotBlank() }
-}
-
-/**
  * Copy [sourceDir] into [targetDir] recursively, while also copying original file attributes
  *
  * @param sourceDir source directory
@@ -61,4 +42,23 @@ fun copyRecursivelyWithAttributes(sourceDir: File, targetDir: File) {
             StandardCopyOption.COPY_ATTRIBUTES,
         )
     }
+}
+
+/**
+ * @param hostname hostname to be resolved via `hosts` file
+ * @return IP address of [hostname] if it has been found or null
+ */
+private fun resolve(hostname: String): String? {
+    val process = ProcessBuilder(
+        "bash", "-c",
+        "getent hosts $hostname | awk '{print \$1}'"
+    )
+        .start()
+    process.waitFor()
+    return process.inputStream
+        .readAllBytes()
+        .decodeToString()
+        .lines()
+        .firstOrNull()
+        ?.takeIf { it.isNotBlank() }
 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
@@ -10,10 +10,20 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 /**
+ * @return IP address of the docker host
+ */
+fun getHostIp(): String? {
+    System.getenv("HOST_IP")?.let {
+        return it
+    }
+    return resolve("host.docker.internal")
+}
+
+/**
  * @param hostname hostname to be resolved via `hosts` file
  * @return IP address of [hostname] if it has been found or null
  */
-fun getHostIp(hostname: String): String? {
+private fun resolve(hostname: String): String? {
     val process = ProcessBuilder(
         "bash", "-c",
         "getent hosts $hostname | awk '{print \$1}'"

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -153,7 +153,7 @@ class ContainerManager(private val settings: DockerSettings,
                 """.trimMargin()
         val dockerFile = createTempFile(tmpDir.toPath()).toFile()
         dockerFile.writeText(dockerFileAsText)
-        val hostIp = getHostIp("host.docker.internal")
+        val hostIp = getHostIp()
         log.debug("Resolved host IP as $hostIp, will add it to the container")
         val buildImageResultCallback: BuildImageResultCallback = try {
             val buildCmd = dockerClient.buildImageCmd(dockerFile)


### PR DESCRIPTION
Another preparation step for #671

* Gateway: read OAuth properties from secrets in `kubernetes` profile
* Backend: move postprocessor into a separate profile, add kubernetes support for database credentials
* Support setting host IP for orchestrator via env variable `HOST_IP`