### PR TITLE
Orchestrator: Don't rely on `host-gateway`

### DIFF
--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/LinuxUtils.kt
@@ -10,13 +10,14 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 /**
- * @return IP address of the docker host
+ * @return IP address of the docker host or `host-gateway` as a fallback
  */
-fun getHostIp(): String? {
+fun getHostIp(): String {
     System.getenv("HOST_IP")?.let {
         return it
     }
     return resolve("host.docker.internal")
+        ?: "host-gateway"
 }
 
 /**

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/docker/ContainerManager.kt
@@ -83,7 +83,7 @@ class ContainerManager(private val settings: DockerSettings,
             .withHostConfig(HostConfig.newHostConfig()
                 .withRuntime(settings.runtime)
                 // processes from inside the container will be able to access host's network using this hostname
-                .withExtraHosts("host.docker.internal:host-gateway")
+                .withExtraHosts("host.docker.internal:${getHostIp()}")
                 .withLogConfig(
                     when (settings.loggingDriver) {
                         "loki" -> LogConfig(
@@ -159,9 +159,7 @@ class ContainerManager(private val settings: DockerSettings,
             val buildCmd = dockerClient.buildImageCmd(dockerFile)
                 .withBaseDirectory(tmpDir)
                 .withTags(setOf(imageName))
-                .withExtraHosts(hostIp?.let {
-                    setOf("host.docker.internal:$hostIp")
-                } ?: emptySet())
+                .withExtraHosts(setOf("host.docker.internal:$hostIp"))
             buildCmd.execTimed(meterRegistry, "save.orchestrator.docker.build", "baseImage", baseImage) { record ->
                 object : BuildImageResultCallback() {
                     override fun onComplete() {


### PR DESCRIPTION
`host-gateway` is a useful alias for host IP, but it's not always available in Docker and also hard to replicate in systems like Kubernetes. Since we already have functionality to get actual IP representation of host, we can use it here too.

Continuation of #707 