### PR TITLE
Kubernetes: Support database migrations using init-containers

### DIFF
--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DatabaseUtils.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DatabaseUtils.kt
@@ -25,17 +25,17 @@ fun Project.getDatabaseCredentials(profile: String): DatabaseCredentials {
 
     val secretsPath = System.getenv("DB_SECRETS_PATH")
     if (secretsPath != null) {
+        // Branch for environment with explicit file with database credentials, e.g. Kubernetes Secrets
         val url = file("$secretsPath/spring.datasource.url").readText()
         val username = file("$secretsPath/spring.datasource.username").readText()
         val password = file("$secretsPath/spring.datasource.password").readText()
         return DatabaseCredentials(url, username, password)
     } else {
-        file("save-backend/src/main/resources/application-$profile.properties").apply {
-            props.load(inputStream())
-        }
+        // Branch for other environments, e.g. local deployment or server deployment
+        file("save-backend/src/main/resources/application-$profile.properties").inputStream().use(props::load)
 
-        if (File("${System.getenv()["HOME"]}/secrets").exists()) {
-            file("${System.getenv()["HOME"]}/secrets").apply { props.load(inputStream()) }
+        if (File("${System.getenv("HOME")}/secrets").exists()) {
+            file("${System.getenv("HOME")}/secrets").inputStream().use(props::load)
         }
     }
 

--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DatabaseUtils.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/DatabaseUtils.kt
@@ -22,12 +22,21 @@ data class DatabaseCredentials(
  */
 fun Project.getDatabaseCredentials(profile: String): DatabaseCredentials {
     val props = java.util.Properties()
-    file("save-backend/src/main/resources/application-$profile.properties").apply {
-        props.load(inputStream())
-    }
 
-    if (File("${System.getenv()["HOME"]}/secrets").exists()) {
-        file("${System.getenv()["HOME"]}/secrets").apply { props.load(inputStream()) }
+    val secretsPath = System.getenv("DB_SECRETS_PATH")
+    if (secretsPath != null) {
+        val url = file("$secretsPath/spring.datasource.url").readText()
+        val username = file("$secretsPath/spring.datasource.username").readText()
+        val password = file("$secretsPath/spring.datasource.password").readText()
+        return DatabaseCredentials(url, username, password)
+    } else {
+        file("save-backend/src/main/resources/application-$profile.properties").apply {
+            props.load(inputStream())
+        }
+
+        if (File("${System.getenv()["HOME"]}/secrets").exists()) {
+            file("${System.getenv()["HOME"]}/secrets").apply { props.load(inputStream()) }
+        }
     }
 
     val databaseUrl: String

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/postprocessor/DockerSecretsDatabaseProcessor.kt
@@ -1,9 +1,8 @@
 package org.cqfn.save.backend.postprocessor
 
-import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.env.EnvironmentPostProcessor
-import org.springframework.context.annotation.Profile
+import org.springframework.boot.logging.DeferredLogFactory
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.PropertiesPropertySource
 import org.springframework.core.io.FileSystemResource
@@ -14,11 +13,18 @@ import java.util.Properties
 /**
  * Post processor that collects credentials for database from docker secrets
  */
-@Profile("docker-secrets")
-class DockerSecretsDatabaseProcessor : EnvironmentPostProcessor {
-    private val log = LoggerFactory.getLogger(DockerSecretsDatabaseProcessor::class.java)
+class DockerSecretsDatabaseProcessor(
+    logFactory: DeferredLogFactory
+) : EnvironmentPostProcessor {
+    private val log = logFactory.getLog(DockerSecretsDatabaseProcessor::class.java)
 
     override fun postProcessEnvironment(environment: ConfigurableEnvironment, application: SpringApplication) {
+        // Since `EnvironmentPostProcessor` is created before application context is fully initialized, usual means of registration control
+        // like `@Profile` cannot be used. `environment` here should contain at least profiles set from env variable or system properties.
+        if ("docker-secrets" !in environment.activeProfiles) {
+            log.debug("Skipping activation of ${this::class.simpleName} because of active profiles")
+            return
+        }
         val secretsBasePath = System.getenv("DB_PASSWORD_FILE") ?: "/run/secrets"
         log.debug("Started DockerSecretsDatabaseProcessor [EnvironmentPostProcessor] configured to look up secrets in $secretsBasePath")
         val passwordResource = FileSystemResource("$secretsBasePath/db_password")

--- a/save-cloud-charts/save-cloud/README.md
+++ b/save-cloud-charts/save-cloud/README.md
@@ -6,6 +6,7 @@ api-gateway acts as an entrypoint and svc/gateway is actually a LoadBalancer.
 
 ## Prerequisites
 * `kubectl create secret generic db-secrets --from_literal=db_url=<...> --from_literal=db_username=<...> --from_literal=db_password=<...>`
+  For example, for minikube and dev profile run `kubectl --context=minikube --namespace=save-cloud create secret generic db-secrets --from_literal=db_url=jdbc:mysql://mysql-service:3306/save_cloud --from_literal=db_username=root --from_literal=db_password=123`
 * `kubectl create secret generic oauth-credentials ...` this secret should contain properties recognizable by spring security OAuth
 
 ## Build and deploy

--- a/save-cloud-charts/save-cloud/README.md
+++ b/save-cloud-charts/save-cloud/README.md
@@ -5,8 +5,15 @@ It will also create a Service for an external MySQL database.
 api-gateway acts as an entrypoint and svc/gateway is actually a LoadBalancer.
 
 ## Prerequisites
-* `kubectl create secret generic db-secrets --from_literal=db_url=<...> --from_literal=db_username=<...> --from_literal=db_password=<...>`
-  For example, for minikube and dev profile run `kubectl --context=minikube --namespace=save-cloud create secret generic db-secrets --from_literal=db_url=jdbc:mysql://mysql-service:3306/save_cloud --from_literal=db_username=root --from_literal=db_password=123`
+* save-backend expects the following secrets to be set under the secret `db-secrets` (`kubectl create secret generic db-secrets <...>`, 
+  also see Secrets section in dev profile in [mysql-deployment.yaml](templates/mysql-deployment.yaml) as a reference): 
+  * `spring.datasource.url`
+  * `spring.datasource.username`
+  * `spring.datasource.password`
+  
+  These secrets are then mounted under the path specified as `DATABASE_SECRETS_PATH` environment variable.
+
+  For example, for minikube and dev profile run `kubectl --context=minikube --namespace=save-cloud create secret generic db-secrets --from_literal=spring.datasource.username=<...> <...>`
 * `kubectl create secret generic oauth-credentials ...` this secret should contain properties recognizable by spring security OAuth
 
 ## Build and deploy

--- a/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
@@ -29,30 +29,40 @@ spec:
             - name: database-secret
               mountPath: {{ .Values.backend.dbPasswordFile }}
           {{- include "spring-boot.management" .Values.backend | nindent 10 }}
-#      initContainers:
-#        - name: git-cloner
-#          image: alpine/git
-#          args:
-#            - clone
-#            - --single-branch
-#            - --
-#            - https://github.com/analysis-dev/save-cloud.git
-#            - /data
-#          volumeMounts:
-#            - mountPath: /data
-#              name: migrations-data
+      initContainers:
+        - name: git-cloner
+          image: alpine/git
+          args:
+            - clone
+            - --single-branch
+#            - --branch
+#            - feature/k8s-init-containers
+            - --
+            - https://github.com/analysis-dev/save-cloud.git
+            - /data
+          volumeMounts:
+            - mountPath: /data
+              name: migrations-data
+        - name: liquibase-runner
+          image: gradle:7.4.2-jdk11-alpine
+          workingDir: /data
+          args:
+            - ./gradlew
+            - -Psave.profile={{ .Values.profile }}
+            - liquibaseUpdate
+          env:
+            - name: DB_SECRETS_PATH
+              value: {{ .Values.backend.dbPasswordFile }}
+          volumeMounts:
+            - mountPath: /data
+              name: migrations-data
+            - mountPath: {{ .Values.backend.dbPasswordFile }}
+              name: database-secret
 #        - name: liquibase-runner
-#          image: gradle:7.4.2
-#          workingDir: /data
+#          image: liquibase/liquibase
 #          args:
-#            - ./gradlew
-#            - -Psave.profile={{ .Values.profile }}
-#            - liquibaseUpdate
-##        - name: liquibase-runner
-##          image: liquibase/liquibase
-##          args:
-##            - docker-entrypoint.sh
-##            - --url=
+#            - docker-entrypoint.sh
+#            - --url=
       volumes:
         - {{ include "spring-boot.config-volume" (dict "service" .Values.backend) | indent 10 | trim }}
         - name: fs-storage

--- a/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
@@ -58,11 +58,6 @@ spec:
               name: migrations-data
             - mountPath: {{ .Values.backend.dbPasswordFile }}
               name: database-secret
-#        - name: liquibase-runner
-#          image: liquibase/liquibase
-#          args:
-#            - docker-entrypoint.sh
-#            - --url=
       volumes:
         - {{ include "spring-boot.config-volume" (dict "service" .Values.backend) | indent 10 | trim }}
         - name: fs-storage

--- a/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
@@ -35,8 +35,6 @@ spec:
           args:
             - clone
             - --single-branch
-#            - --branch
-#            - feature/k8s-init-containers
             - --
             - https://github.com/analysis-dev/save-cloud.git
             - /data

--- a/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
@@ -20,10 +20,8 @@ spec:
           {{- include "spring-boot.common" (merge (dict "service" .Values.backend) .) | nindent 10 }}
           env:
             {{- include "spring-boot.common.env" (merge (dict "service" .Values.backend) .) | nindent 12 }}
-            - name: DB_PASSWORD_FILE
-              value: {{ .Values.backend.dbPasswordFile }}
             - name: DATABASE_SECRETS_PATH
-              value: /home/cnb/secrets/db_secrets
+              value: {{ .Values.backend.dbPasswordFile }}
           volumeMounts:
             - {{ include "spring-boot.config-volume-mount" . | indent 14 | trim }}
             - name: fs-storage

--- a/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/backend-deployment.yaml
@@ -22,6 +22,8 @@ spec:
             {{- include "spring-boot.common.env" (merge (dict "service" .Values.backend) .) | nindent 12 }}
             - name: DB_PASSWORD_FILE
               value: {{ .Values.backend.dbPasswordFile }}
+            - name: DATABASE_SECRETS_PATH
+              value: /home/cnb/secrets/db_secrets
           volumeMounts:
             - {{ include "spring-boot.config-volume-mount" . | indent 14 | trim }}
             - name: fs-storage
@@ -29,6 +31,30 @@ spec:
             - name: database-secret
               mountPath: {{ .Values.backend.dbPasswordFile }}
           {{- include "spring-boot.management" .Values.backend | nindent 10 }}
+#      initContainers:
+#        - name: git-cloner
+#          image: alpine/git
+#          args:
+#            - clone
+#            - --single-branch
+#            - --
+#            - https://github.com/analysis-dev/save-cloud.git
+#            - /data
+#          volumeMounts:
+#            - mountPath: /data
+#              name: migrations-data
+#        - name: liquibase-runner
+#          image: gradle:7.4.2
+#          workingDir: /data
+#          args:
+#            - ./gradlew
+#            - -Psave.profile={{ .Values.profile }}
+#            - liquibaseUpdate
+##        - name: liquibase-runner
+##          image: liquibase/liquibase
+##          args:
+##            - docker-entrypoint.sh
+##            - --url=
       volumes:
         - {{ include "spring-boot.config-volume" (dict "service" .Values.backend) | indent 10 | trim }}
         - name: fs-storage
@@ -37,3 +63,5 @@ spec:
         - name: database-secret
           secret:
             secretName: db-secrets
+        - name: migrations-data
+          emptyDir: {}

--- a/save-cloud-charts/save-cloud/templates/database-service.yaml
+++ b/save-cloud-charts/save-cloud/templates/database-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mysql.external -}}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -21,3 +22,17 @@ spec:
       protocol: TCP
   selector: {}
   type: ClusterIP
+
+{{- else }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+spec:
+  ports:
+    - port: 3306
+  selector:
+    io.kompose.service: mysql
+#  clusterIP: None
+{{- end }}

--- a/save-cloud-charts/save-cloud/templates/database-service.yaml
+++ b/save-cloud-charts/save-cloud/templates/database-service.yaml
@@ -34,5 +34,5 @@ spec:
     - port: 3306
   selector:
     io.kompose.service: mysql
-#  clusterIP: None
+  clusterIP: None
 {{- end }}

--- a/save-cloud-charts/save-cloud/templates/mysql-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/mysql-deployment.yaml
@@ -1,18 +1,17 @@
 {{- if not .Values.mysql.external -}}
+
+  {{- if eq .Values.profile "dev" -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: db-secrets
 stringData:
-  # TODO: accidentally PostProcessor and k8s-client-config try to read properties simultaneously...
-  db_url: 'jdbc:mysql://mysql-service:3306/save_cloud'
-  db_username: root
-  db_password: '123'
   spring.datasource.url: 'jdbc:mysql://mysql-service:3306/save_cloud'
   spring.datasource.username: root
   spring.datasource.password: '123'
 
 ---
+  {{ end }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/save-cloud-charts/save-cloud/templates/mysql-deployment.yaml
+++ b/save-cloud-charts/save-cloud/templates/mysql-deployment.yaml
@@ -1,0 +1,50 @@
+{{- if not .Values.mysql.external -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secrets
+stringData:
+  # TODO: accidentally PostProcessor and k8s-client-config try to read properties simultaneously...
+  db_url: 'jdbc:mysql://mysql-service:3306/save_cloud'
+  db_username: root
+  db_password: '123'
+  spring.datasource.url: 'jdbc:mysql://mysql-service:3306/save_cloud'
+  spring.datasource.username: root
+  spring.datasource.password: '123'
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  annotations:
+    io.kompose.service: mysql
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: mysql
+  template:
+    metadata:
+      labels:
+        io.kompose.service: mysql
+    spec:
+      containers:
+        - image: mysql:8.0.28
+          name: mysql
+          ports:
+            - containerPort: 3306
+              name: mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: '123'
+            - name: MYSQL_DATABASE
+              value: save_cloud
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-persistent-storage
+          hostPath:
+            path: /home/data/mysql
+{{- end }}

--- a/save-cloud-charts/save-cloud/values-minikube.yaml
+++ b/save-cloud-charts/save-cloud/values-minikube.yaml
@@ -10,6 +10,7 @@ gateway:
     management.endpoints.web.exposure.include=*
     gateway.knownActuatorConsumers=172.0.0.0/8
 mysql:
-  ip: 192.168.65.2
+  external: false
+  ip: nil
 
 # dependencies

--- a/save-cloud-charts/save-cloud/values.yaml
+++ b/save-cloud-charts/save-cloud/values.yaml
@@ -43,6 +43,9 @@ reposStorage:
 logsStorage:
   size: 2Gi
 mysql:
+  # If true, a Service will be created to enable communication with an external DB by its IP.
+  # If false, a Deployment will be created for a MySQL pod.
+  external: true
   # IP address of an external MySQL database.
   # As an example, this is what may be a resolved IP of `host.minikube.internal`.
   ip: 192.168.65.2


### PR DESCRIPTION
* Helm: Add init-containers for save-backend Deployment to run database migrations with gradle and liquibase
* Gradle: Reading database credentials using path from environment variable
* Helm: Add configs to deploy MySQL into Kubernetes cluster (enabled by `mysql.external: false` in Helm values), update Secrets for dev profile, update README.md
* Backend: Correctly disable DockerSecretsDatabaseProcessor depending on profiles
* Backend: Use deferred logger in DockerSecretsDatabaseProcessor

Caveats:
* Gradle takes a lot of time to take off inside a container, because it needs to download a lot of dependencies. However, we have a lot of control on reading secrets and still can have depoyment procedures unified for different cases. To mitigate this, we can build our own base image for builds and publish to ghcr (update on every gradle and/or Kotlin version changes). It can also be used inside Github Actions.